### PR TITLE
add create_sandbox.json.j2

### DIFF
--- a/samples/tasks/scenarios/ovn-sandbox/create_sandbox.json.j2
+++ b/samples/tasks/scenarios/ovn-sandbox/create_sandbox.json.j2
@@ -1,0 +1,29 @@
+{% set farm = farm or "ovn-farm-node-0" %}
+{% set amount = amount or 1 %}
+{% set start_cidr = start_cidr or "192.168.64.0/16" %}
+{% set tag = tag or "" %}
+{
+    "version": 2,
+    "title": "Create sandbox",
+    "subtasks": [{
+        "title": "Create sandboxes",
+        "workloads": [{
+            "name": "OvnSandbox.create_sandbox",
+            "args": {
+                "sandbox_create_args": {
+                    "farm": "{{farm}}",
+                    "amount": {{amount}},
+                    "batch": 50,
+                    "start_cidr": "{{start_cidr}}",
+                    "net_dev": "eth0",
+                    "tag": "{{tag}}"
+                }
+            },
+            "runner": { "type": "serial", "times": 1 },
+            "context": {
+               "ovn_multihost" : {"controller": "ovn-controller-node"}
+            }
+        }]
+    }]
+}
+


### PR DESCRIPTION
For creating sandboxes on multiple farm nodes, you can run rally-ovs multiple times for each farm node, e.g.:

$ rally-ovs task start create_sandbox.json.j2 --task-args '{"farm":"ovn-sandbox-node-0", "start_cidr":"192.168.1.0/16", "tag":"ToR-01", "amount":10}'
$ rally-ovs task start create_sandbox.json.j2 --task-args '{"farm":"ovn-sandbox-node-1", "start_cidr":"192.168.2.0/16", "tag":"ToR-02", "amount":10}'
