### PR TITLE
prepare.sh: Make user creation conditional

### DIFF
--- a/rally_ovs/plugins/ovs/deployment/engines/ovs/prepare.sh
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovs/prepare.sh
@@ -6,9 +6,13 @@ OVS_USER=$1
 
 echo "Prepare user $OVS_USER for ovs deployment"
 
-useradd $OVS_USER -m || echo "User $OVS_USER is already exists" >&2
-mkdir -m 700 /home/$OVS_USER/.ssh || true
-cp /root/.ssh/authorized_keys /home/$OVS_USER/.ssh/ || true
+# Check for an existing user
+_USER=$(grep $OVS_USER /etc/passwd)
+if [ "$_USER" == "" ]; then
+    useradd $OVS_USER -m || echo "Error adding user $OVS_USER" >&2
+    mkdir -m 700 /home/$OVS_USER/.ssh || true
+fi
+cp -f /root/.ssh/authorized_keys /home/$OVS_USER/.ssh/ || true
 chown -R $OVS_USER /home/$OVS_USER/.ssh || true
 
 if [ `cat /etc/sudoers | grep $OVS_USER -c` = 0 ]; then


### PR DESCRIPTION
I've run into an issue where when trying to deploy rally fails because
a subsequent "useradd" is rejected. This commits makes adding the user
conditional and thus allows my deployment to proceed.

Signed-off-by: Kyle Mestery mestery@mestery.com
