### PR TITLE
Thin containers for OVN control plane processes

### DIFF
--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -99,6 +99,16 @@ For example, to define the total number of emulated chasis in the network:
 During deployment, these chassis will be evenly distributed on the emulation
 hosts, which are defined in the inventory file.
 
+OVN control containers can also be pinned to particular cores by setting the
+following variables.
+
+::
+
+   north_db_cpu_set: "1"
+   south_db_cpu_set: "2"
+   northd_cpu_set: "3"
+
+
 Deploying OVN Emulation
 -----------------------
 
@@ -108,9 +118,9 @@ Run the ansible playbook
 
     ansible-playbook  -i ansible/inventory/ovn-hosts ansible/site.yml -e action=deploy
 
-The above command deploys ovn-database and the emulated chassis. On the rally
-node, an ovn-rally container is also launched as well as the deployment file and
-workload files.
+The above command deploys ovn control plane containers and the emulated chassis.
+On the rally node, an ovn-rally container is also launched as well as the
+deployment file and workload files.
 
 Ansible allows you to overide the variables in group_vars/all.yml. For example,
 some variables are defined in a separate file, named

--- a/ansible/docker/ovn/Dockerfile
+++ b/ansible/docker/ovn/Dockerfile
@@ -14,4 +14,11 @@ RUN chmod 755 /bin/ovn_set_database
 COPY ovn-sandbox-chassis.sh /bin/ovn_set_chassis
 RUN chmod 755 /bin/ovn_set_chassis
 
+COPY ovn-sandbox-north-ovsdb.sh /bin/ovn-sandbox-north-ovsdb.sh
+COPY ovn-sandbox-south-ovsdb.sh /bin/ovn-sandbox-south-ovsdb.sh
+COPY ovn-sandbox-northd.sh /bin/ovn-sandbox-northd.sh
+RUN chmod 755 /bin/ovn-sandbox-north-ovsdb.sh \
+              /bin/ovn-sandbox-south-ovsdb.sh \
+              /bin/ovn-sandbox-northd.sh
+
 # ENTRYPOINT ["/usr/local/bin/ovn_set_database"]

--- a/ansible/docker/ovn/ovn-sandbox-north-ovsdb.sh
+++ b/ansible/docker/ovn/ovn-sandbox-north-ovsdb.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+set -eu
+
+run() {
+    (cd "$sandbox" && "$@") || exit 1
+}
+
+
+schema=/usr/local/share/openvswitch/vswitch.ovsschema
+ovnsb_schema=/usr/local/share/openvswitch/ovn-sb.ovsschema
+ovnnb_schema=/usr/local/share/openvswitch/ovn-nb.ovsschema
+
+controller_ip=$1
+device=$2
+
+#
+# IP related code start
+#
+declare -a IP_CIDR_ARRAY
+declare -A IP_NETMASK_TABLE
+
+function get_ip_cidrs {
+    dev=$1
+
+    i=0
+    IFS=$'\n'
+    #echo "$dev ip cidrs:"
+    #echo "---------------------------"
+    for inet in `ip addr show $dev | grep -e 'inet\b'` ; do
+        local ip_cidr=`echo $inet | \
+            sed -n  -e  's%.*inet \(\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}/[0-9]\+\) .*%\1%p'`
+
+        IFS=' '
+        read ip_addr netmask <<<$(echo $ip_cidr | sed -e 's/\// /')
+        IP_CIDR_ARRAY[i]=$ip_cidr
+        IP_NETMASK_TABLE[$ip_addr]=$netmask
+
+        #echo "    cidr $ip_cidr"
+        ((i+=1))
+    done
+
+    #echo IP_CIDR_ARRAY: ${IP_CIDR_ARRAY[@]}
+}
+
+
+function in_array # ( keyOrValue, arrayKeysOrValues )
+{
+    local elem=$1
+
+    IFS=' '
+    local i
+    for i in "${@:2}"; do
+        #echo "$i == $elem"
+        [[ "$i" == "$elem" ]] && return 0;
+    done
+
+    return 1
+}
+
+
+function get_ip_from_cidr {
+    local cidr=$1
+    echo $cidr | cut -d'/' -f1
+}
+
+function get_netmask_from_cidr {
+    local cidr=$1
+    echo $cidr | cut -d'/' -f2
+}
+
+
+function ip_addr_add {
+    local ip=$1
+    local dev=$2
+
+    if in_array $ip ${IP_CIDR_ARRAY[@]} ; then
+        echo "$ip is already on $dev"
+        return
+    fi
+
+    echo "Add $ip to $dev"
+    sudo ip addr add $ip dev $dev
+}
+
+
+function ip_cidr_fixup {
+    local ip=$1
+    if [[ ! "$ip" =~ "/" ]] ; then
+        echo $ip"/32"
+        return
+    fi
+
+    echo $ip
+}
+
+#
+# IP related code end
+#
+
+# Create sandbox.
+# sandbox_name="controller-sandbox"
+sandbox_name="/usr/local/var/run/openvswitch/"
+
+sandbox=$sandbox_name
+
+# Get ip addresses on net device
+get_ip_cidrs $device
+
+
+# A UUID to uniquely identify this system.  If one is not specified, a random
+# one will be generated.  A randomly generated UUID will be saved in a file
+# 'ovn-uuid'.
+OVN_UUID=${OVN_UUID:-}
+
+function configure_ovn {
+    echo "Configuring OVN"
+
+    if [ -z "$OVN_UUID" ] ; then
+        if [ -f /usr/local/var/run/openvswitch/ovn-uuid ] ; then
+            OVN_UUID=$(cat /usr/local/var/run/openvswitch/ovn-uuid)
+        else
+            OVN_UUID=$(uuidgen)
+            echo $OVN_UUID > /usr/local/var/run/openvswitch/ovn-uuid
+        fi
+    fi
+}
+
+
+function init_ovsdb_server {
+
+    server_name=$1
+    db=$2
+    db_sock=`basename $2`
+
+    #Wait for ovsdb-server to finish launching.
+    echo -n "Waiting for $server_name to start..."
+    while test ! -e "$sandbox"/$db_sock; do
+        sleep 1;
+    done
+    echo "  Done"
+
+    run ovs-vsctl --db=$db --no-wait -- init
+}
+
+
+
+function start_ovs {
+    # Create database and start ovsdb-server.
+    echo "Starting OVS"
+
+    CON_IP=`get_ip_from_cidr $controller_ip`
+    echo "controller ip: $CON_IP"
+
+    EXTRA_DBS=""
+    OVSDB_REMOTE=""
+
+    touch "$sandbox"/.conf-nb.db.~lock~
+
+    run ovsdb-tool create conf-nb.db "$schema"
+
+
+    touch "$sandbox"/.ovnnb.db.~lock~
+
+    run ovsdb-tool create ovnnb.db "$ovnnb_schema"
+
+    ip_addr_add $controller_ip $device
+
+    OVSDB_REMOTE="ptcp\:6640\:$CON_IP"
+
+    # Northbound db server
+    prog_name='ovsdb-server-nb'
+    run ovsdb-server --no-chdir --pidfile=$prog_name.pid \
+        --unixctl=$prog_name.ctl \
+        -vconsole:off -vsyslog:off -vfile:info \
+	--log-file=$prog_name.log \
+        --remote=punix:/usr/local/var/run/openvswitch/ovnnb_db.sock \
+        conf-nb.db ovnnb.db
+    pid=`cat $sandbox_name/$prog_name.pid`
+    mv $sandbox_name/$prog_name.ctl $sandbox_name/$prog_name.$pid.ctl
+}
+
+function start_ovn {
+    echo "Starting OVN northd"
+
+    run ovn-northd  --no-chdir --pidfile \
+              -vconsole:off -vsyslog:off -vfile:info --log-file \
+              --ovnnb-db=unix:/usr/local/var/run/openvswitch/ovnnb_db.sock \
+              --ovnsb-db=unix:/usr/local/var/run/openvswitch/ovnsb_db.sock
+}
+
+configure_ovn
+
+start_ovs

--- a/ansible/docker/ovn/ovn-sandbox-northd.sh
+++ b/ansible/docker/ovn/ovn-sandbox-northd.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+set -eu
+
+run() {
+    (cd "$sandbox" && "$@") || exit 1
+}
+
+
+schema=/usr/local/share/openvswitch/vswitch.ovsschema
+ovnsb_schema=/usr/local/share/openvswitch/ovn-sb.ovsschema
+ovnnb_schema=/usr/local/share/openvswitch/ovn-nb.ovsschema
+
+controller_ip=$1
+device=$2
+
+#
+# IP related code start
+#
+declare -a IP_CIDR_ARRAY
+declare -A IP_NETMASK_TABLE
+
+function get_ip_cidrs {
+    dev=$1
+
+    i=0
+    IFS=$'\n'
+    #echo "$dev ip cidrs:"
+    #echo "---------------------------"
+    for inet in `ip addr show $dev | grep -e 'inet\b'` ; do
+        local ip_cidr=`echo $inet | \
+            sed -n  -e  's%.*inet \(\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}/[0-9]\+\) .*%\1%p'`
+
+        IFS=' '
+        read ip_addr netmask <<<$(echo $ip_cidr | sed -e 's/\// /')
+        IP_CIDR_ARRAY[i]=$ip_cidr
+        IP_NETMASK_TABLE[$ip_addr]=$netmask
+
+        #echo "    cidr $ip_cidr"
+        ((i+=1))
+    done
+
+    #echo IP_CIDR_ARRAY: ${IP_CIDR_ARRAY[@]}
+}
+
+
+function in_array # ( keyOrValue, arrayKeysOrValues )
+{
+    local elem=$1
+
+    IFS=' '
+    local i
+    for i in "${@:2}"; do
+        #echo "$i == $elem"
+        [[ "$i" == "$elem" ]] && return 0;
+    done
+
+    return 1
+}
+
+
+function get_ip_from_cidr {
+    local cidr=$1
+    echo $cidr | cut -d'/' -f1
+}
+
+function get_netmask_from_cidr {
+    local cidr=$1
+    echo $cidr | cut -d'/' -f2
+}
+
+
+function ip_addr_add {
+    local ip=$1
+    local dev=$2
+
+    if in_array $ip ${IP_CIDR_ARRAY[@]} ; then
+        echo "$ip is already on $dev"
+        return
+    fi
+
+    echo "Add $ip to $dev"
+    sudo ip addr add $ip dev $dev
+}
+
+
+function ip_cidr_fixup {
+    local ip=$1
+    if [[ ! "$ip" =~ "/" ]] ; then
+        echo $ip"/32"
+        return
+    fi
+
+    echo $ip
+}
+
+#
+# IP related code end
+#
+
+# Create sandbox.
+# sandbox_name="controller-sandbox"
+sandbox_name="/usr/local/var/run/openvswitch/"
+
+sandbox=$sandbox_name
+
+# Get ip addresses on net device
+get_ip_cidrs $device
+
+
+# A UUID to uniquely identify this system.  If one is not specified, a random
+# one will be generated.  A randomly generated UUID will be saved in a file
+# 'ovn-uuid'.
+OVN_UUID=${OVN_UUID:-}
+
+function configure_ovn {
+    echo "Configuring OVN"
+
+    if [ -z "$OVN_UUID" ] ; then
+        if [ -f /usr/local/var/run/openvswitch/ovn-uuid ] ; then
+            OVN_UUID=$(cat /usr/local/var/run/openvswitch/ovn-uuid)
+        else
+            OVN_UUID=$(uuidgen)
+            echo $OVN_UUID > /usr/local/var/run/openvswitch/ovn-uuid
+        fi
+    fi
+}
+
+
+function init_ovsdb_server {
+
+    server_name=$1
+    db=$2
+    db_sock=`basename $2`
+
+    #Wait for ovsdb-server to finish launching.
+    echo -n "Waiting for $server_name to start..."
+    while test ! -e "$sandbox"/$db_sock; do
+        sleep 1;
+    done
+    echo "  Done"
+
+    run ovs-vsctl --db=$db --no-wait -- init
+}
+
+
+function start_ovs {
+    # Create database and start ovsdb-server.
+    echo "Starting OVS"
+
+    CON_IP=`get_ip_from_cidr $controller_ip`
+    echo "controller ip: $CON_IP"
+
+    EXTRA_DBS=""
+    OVSDB_REMOTE=""
+
+    OVSDB_REMOTE="ptcp\:6640\:$CON_IP"
+
+    #Add a small delay to allow ovsdb-server to launch.
+    sleep 0.1
+
+    init_ovsdb_server "ovsdb-server-nb" unix:/usr/local/var/run/openvswitch/ovnnb_db.sock
+    init_ovsdb_server "ovsdb-server-sb" unix:/usr/local/var/run/openvswitch/ovnsb_db.sock
+
+    ovs-vsctl --db=unix:/usr/local/var/run/openvswitch/ovnsb_db.sock --no-wait \
+        -- set open_vswitch .  manager_options=@uuid \
+        -- --id=@uuid create Manager target="$OVSDB_REMOTE" inactivity_probe=0
+}
+
+function start_ovn {
+    echo "Starting OVN northd"
+
+    run ovn-northd  --no-chdir --pidfile \
+              -vconsole:off -vsyslog:off -vfile:info --log-file \
+              --ovnnb-db=unix:/usr/local/var/run/openvswitch/ovnnb_db.sock \
+              --ovnsb-db=unix:/usr/local/var/run/openvswitch/ovnsb_db.sock
+}
+
+configure_ovn
+
+start_ovs
+
+start_ovn

--- a/ansible/docker/ovn/ovn-sandbox-south-ovsdb.sh
+++ b/ansible/docker/ovn/ovn-sandbox-south-ovsdb.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -eu
+
+run() {
+    (cd "$sandbox" && "$@") || exit 1
+}
+
+
+schema=/usr/local/share/openvswitch/vswitch.ovsschema
+ovnsb_schema=/usr/local/share/openvswitch/ovn-sb.ovsschema
+ovnnb_schema=/usr/local/share/openvswitch/ovn-nb.ovsschema
+
+controller_ip=$1
+device=$2
+
+#
+# IP related code start
+#
+declare -a IP_CIDR_ARRAY
+declare -A IP_NETMASK_TABLE
+
+function get_ip_cidrs {
+    dev=$1
+
+    i=0
+    IFS=$'\n'
+    #echo "$dev ip cidrs:"
+    #echo "---------------------------"
+    for inet in `ip addr show $dev | grep -e 'inet\b'` ; do
+        local ip_cidr=`echo $inet | \
+            sed -n  -e  's%.*inet \(\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}/[0-9]\+\) .*%\1%p'`
+
+        IFS=' '
+        read ip_addr netmask <<<$(echo $ip_cidr | sed -e 's/\// /')
+        IP_CIDR_ARRAY[i]=$ip_cidr
+        IP_NETMASK_TABLE[$ip_addr]=$netmask
+
+        #echo "    cidr $ip_cidr"
+        ((i+=1))
+    done
+
+    #echo IP_CIDR_ARRAY: ${IP_CIDR_ARRAY[@]}
+}
+
+
+function in_array # ( keyOrValue, arrayKeysOrValues )
+{
+    local elem=$1
+
+    IFS=' '
+    local i
+    for i in "${@:2}"; do
+        #echo "$i == $elem"
+        [[ "$i" == "$elem" ]] && return 0;
+    done
+
+    return 1
+}
+
+
+function get_ip_from_cidr {
+    local cidr=$1
+    echo $cidr | cut -d'/' -f1
+}
+
+function get_netmask_from_cidr {
+    local cidr=$1
+    echo $cidr | cut -d'/' -f2
+}
+
+
+function ip_addr_add {
+    local ip=$1
+    local dev=$2
+
+    if in_array $ip ${IP_CIDR_ARRAY[@]} ; then
+        echo "$ip is already on $dev"
+        return
+    fi
+
+    echo "Add $ip to $dev"
+    sudo ip addr add $ip dev $dev
+}
+
+
+function ip_cidr_fixup {
+    local ip=$1
+    if [[ ! "$ip" =~ "/" ]] ; then
+        echo $ip"/32"
+        return
+    fi
+
+    echo $ip
+}
+
+#
+# IP related code end
+#
+
+# Create sandbox.
+# sandbox_name="controller-sandbox"
+sandbox_name="/usr/local/var/run/openvswitch/"
+
+sandbox=$sandbox_name
+
+# Get ip addresses on net device
+get_ip_cidrs $device
+
+
+# A UUID to uniquely identify this system.  If one is not specified, a random
+# one will be generated.  A randomly generated UUID will be saved in a file
+# 'ovn-uuid'.
+OVN_UUID=${OVN_UUID:-}
+
+function configure_ovn {
+    echo "Configuring OVN"
+
+    if [ -z "$OVN_UUID" ] ; then
+        if [ -f /usr/local/var/run/openvswitch/ovn-uuid ] ; then
+            OVN_UUID=$(cat /usr/local/var/run/openvswitch/ovn-uuid)
+        else
+            OVN_UUID=$(uuidgen)
+            echo $OVN_UUID > /usr/local/var/run/openvswitch/ovn-uuid
+        fi
+    fi
+}
+
+
+function init_ovsdb_server {
+
+    server_name=$1
+    db=$2
+    db_sock=`basename $2`
+
+    #Wait for ovsdb-server to finish launching.
+    echo -n "Waiting for $server_name to start..."
+    while test ! -e "$sandbox"/$db_sock; do
+        sleep 1;
+    done
+    echo "  Done"
+
+    run ovs-vsctl --db=$db --no-wait -- init
+}
+
+
+
+function start_ovs {
+    # Create database and start ovsdb-server.
+    echo "Starting OVS"
+
+    CON_IP=`get_ip_from_cidr $controller_ip`
+    echo "controller ip: $CON_IP"
+
+    EXTRA_DBS=""
+    OVSDB_REMOTE=""
+
+    touch "$sandbox"/.conf-sb.db.~lock~
+
+    run ovsdb-tool create conf-sb.db "$schema"
+
+    touch "$sandbox"/.ovnsb.db.~lock~
+
+    run ovsdb-tool create ovnsb.db "$ovnsb_schema"
+
+
+    OVSDB_REMOTE="ptcp\:6640\:$CON_IP"
+
+    # Southbound db server
+    prog_name='ovsdb-server-sb'
+    run ovsdb-server --no-chdir --pidfile=$prog_name.pid \
+        --unixctl=$prog_name.ctl \
+        -vconsole:off -vsyslog:off -vfile:info \
+	--log-file=$prog_name.log \
+        --remote=punix:/usr/local/var/run/openvswitch/ovnsb_db.sock \
+        --remote=db:Open_vSwitch,Open_vSwitch,manager_options \
+        conf-sb.db ovnsb.db
+    pid=`cat $sandbox_name/$prog_name.pid`
+    mv $sandbox_name/$prog_name.ctl $sandbox_name/$prog_name.$pid.ctl
+}
+
+function start_ovn {
+    echo "Starting OVN northd"
+
+    run ovn-northd  --no-chdir --pidfile \
+              -vconsole:off -vsyslog:off -vfile:info --log-file \
+              --ovnnb-db=unix:/usr/local/var/run/openvswitch/ovnnb_db.sock \
+              --ovnsb-db=unix:/usr/local/var/run/openvswitch/ovnsb_db.sock
+}
+
+configure_ovn
+
+start_ovs

--- a/ansible/etc/variables.yml
+++ b/ansible/etc/variables.yml
@@ -17,7 +17,7 @@ rally_image: "huikang/ovn-scale-test-rally"
 # Emulation options
 ###################
 
-ovn_database_alias_ip: "172.16.20.100"
+ovn_database_alias_ip: "172.16.20.100/16"
 ovn_database_device: "eth0.3239"
 
 ovn_chassis_start_cidr: "172.16.200.10/16"
@@ -32,4 +32,4 @@ ovn_number_chassis: 5
 ########################
 network_start_cidr: "172.16.201.0/24"
 network_number: "5"
-ports_per_network: "1"
+ports_per_network: "5"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -19,7 +19,7 @@ rally_image: "huikang/ovn-scale-test-rally"
 # Emulation options
 ###################
 
-ovn_database_alias_ip: "172.16.20.100"
+ovn_database_alias_ip: "172.16.20.100/16"
 ovn_database_device: "eth1"
 
 ovn_chassis_start_cidr: "172.16.200.10/16"
@@ -28,6 +28,10 @@ ovn_chassis_device: "eth1"
 # Total number of emulated chassis
 ovn_number_chassis: 5
 
+# pin container to cores, e.g., "29,30,31"
+north_db_cpu_set: ""
+south_db_cpu_set: ""
+northd_cpu_set: ""
 
 ########################
 # Rally workload options

--- a/ansible/inventory/ovn-hosts
+++ b/ansible/inventory/ovn-hosts
@@ -1,6 +1,6 @@
 # You should only add one IP address in this role. The node in this role runs
 # the OVN databse container
-[ovn-database]
+[ovn-control]
 9.2.211.193
 
 # Add host IPs to run emulated OVN chassis

--- a/ansible/roles/ovn/tasks/clean.yml
+++ b/ansible/roles/ovn/tasks/clean.yml
@@ -1,12 +1,21 @@
 ---
-- name: delete OVN database
+- name: delete OVN control plane containers
   docker:
-    name: ovn-database
+    name: "{{ item }}"
     image: "{{ ovn_db_image_full }}"
     pull: always
     state: absent
+  with_items:
+    - "ovn-north-database"
+    - "ovn-south-database"
+    - "ovn-northd"
   when:
-    - inventory_hostname in groups['ovn-database']
+    - inventory_hostname in groups['ovn-control']
+
+- name: delete shared volume for ovn control plane
+  command: docker volume rm ovn-run
+  when:
+    - inventory_hostname in groups['ovn-control']
 
 - name: delete OVN chassis
   docker:
@@ -25,14 +34,14 @@
     - inventory_hostname in groups['emulation-hosts']
   ignore_errors: yes
 
-- name: delete ip alias on the ovn database host
-  command: "ip a del {{ ovn_database_alias_ip }}/32 dev {{ ovn_database_device }}"
+- name: delete ip alias on the ovn control host
+  command: "ip a del {{ ovn_database_alias_ip }} dev {{ ovn_database_device }}"
   when:
-    - inventory_hostname in groups['ovn-database']
+    - inventory_hostname in groups['ovn-control']
   ignore_errors: yes
 
 - name: delete ip alias on the emulation host
-  command: "ip a del {{ item.1 }}/16 dev {{ ovn_chassis_device }}"
+  command: "ip a del {{ item.1 }}/{{ dmi_data['prefixlen'] }} dev {{ ovn_chassis_device }}"
   delegate_to: "{{ groups['emulation-hosts'][ item.0 ] }}"
   with_together:
     - "{{ dmi_data['ip_index'] }}"

--- a/ansible/roles/ovn/tasks/config.yml
+++ b/ansible/roles/ovn/tasks/config.yml
@@ -7,7 +7,7 @@
   with_items:
     - "openvswitch-ovn-db"
   when:
-    - inventory_hostname in groups['ovn-database']
+    - inventory_hostname in groups['ovn-control']
 
 - name: Copying over config.json files for OVN database
   template:
@@ -16,7 +16,7 @@
   with_items:
     - "openvswitch-ovn-db"
   when:
-    - inventory_hostname in groups['ovn-database']
+    - inventory_hostname in groups['ovn-control']
 
 - name: Ensuring config directories exist on chassis host
   file:

--- a/ansible/roles/ovn/tasks/start.yml
+++ b/ansible/roles/ovn/tasks/start.yml
@@ -1,16 +1,56 @@
 ---
-- name: start OVN database
+- name: create shared volume for ovn control plane processes
+  command: docker volume create --name ovn-run
+  when:
+    - inventory_hostname in groups['ovn-control']
+
+- name: start OVN northbound database
   docker:
-    name: ovn-database
+    name: ovn-north-database
     image: "{{ ovn_db_image_full }}"
     pull: always
     privileged: yes
     net: host
     detach: True
     state: started
-    command: "ovn_set_database {{ ovn_database_alias_ip}} {{ ovn_database_device }}"
+    cpu_set: "{{ north_db_cpu_set }}"
+    command: "ovn-sandbox-north-ovsdb.sh {{ ovn_database_alias_ip}} {{ ovn_database_device }}"
+    volumes:
+      - ovn-run:/usr/local/var/run/openvswitch/
   when:
-    - inventory_hostname in groups['ovn-database']
+    - inventory_hostname in groups['ovn-control']
+
+- name: start OVN southbound database
+  docker:
+    name: ovn-south-database
+    image: "{{ ovn_db_image_full }}"
+    pull: always
+    privileged: yes
+    net: host
+    detach: True
+    state: started
+    cpu_set: "{{ south_db_cpu_set }}"
+    command: "ovn-sandbox-south-ovsdb.sh {{ ovn_database_alias_ip}} {{ ovn_database_device }}"
+    volumes:
+      - ovn-run:/usr/local/var/run/openvswitch/
+  when:
+    - inventory_hostname in groups['ovn-control']
+
+- name: start OVN northd
+  docker:
+    name: ovn-northd
+    image: "{{ ovn_db_image_full }}"
+    pull: always
+    privileged: yes
+    net: host
+    detach: True
+    state: started
+    cpu_set: "{{ northd_cpu_set }}"
+    command: "ovn-sandbox-northd.sh {{ ovn_database_alias_ip}} {{ ovn_database_device }}"
+    volumes:
+      - ovn-run:/usr/local/var/run/openvswitch/
+  when:
+    - inventory_hostname in groups['ovn-control']
 
 - name: start OVN chassis
   docker:

--- a/ansible/roles/rally/templates/ovn-multihost-deployment.json.j2
+++ b/ansible/roles/rally/templates/ovn-multihost-deployment.json.j2
@@ -13,7 +13,7 @@
             "type": "OvsSandboxProvider",
             "credentials": [
             {
-                "host": "{{ groups['ovn-database'][0] }}",
+                "host": "{{ groups['ovn-control'][0] }}",
                 "user": "root"}
             ]
         }

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,6 +1,6 @@
 ---
 - hosts:
-    - ovn-database
+    - ovn-control
     - emulation-hosts
   roles:
     - common

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -61,7 +61,7 @@ class OvnNbctl(OvsClient):
                     cmd = itertools.chain(["ovn-nbctl"], opts, [cmd], args)
                     self.cmds.append(" ".join(cmd))
                 elif self.install_method == "docker":
-                    self.cmds.append("sudo docker exec ovn-database ovn-nbctl " + cmd + " " + " ".join(args))
+                    self.cmds.append("sudo docker exec ovn-north-database ovn-nbctl " + cmd + " " + " ".join(args))
 
             self.ssh.run("\n".join(self.cmds),
                          stdout=stdout, stderr=stderr)
@@ -79,7 +79,7 @@ class OvnNbctl(OvsClient):
                     run_cmds.append(". %s/sandbox.rc" % self.sandbox)
                     run_cmds.append("ovn-nbctl" + " ".join(self.cmds))
                 elif self.install_method == "docker":
-                    run_cmds.append("sudo docker exec ovn-database ovn-nbctl " + " ".join(self.cmds))
+                    run_cmds.append("sudo docker exec ovn-north-database ovn-nbctl " + " ".join(self.cmds))
 
             self.ssh.run("\n".join(run_cmds),
                          stdout=sys.stdout, stderr=sys.stderr)


### PR DESCRIPTION
Split ovn-database container into three separate ones:
ovn-north-database, ovn-northd, ovn-south-database

Signed-off-by: Hui Kang kangh@us.ibm.com
