### PR TITLE
Add a ci directory containing scripts for integration with a CI system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ doc/source/_build/
 
 *~
 site.retry
+
+# generated ci/ansible/docker-ovn-hosts file
+ci/ansible/docker-ovn-hosts

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,21 @@
+ovn-scale-cicd
+==============
+
+This project aims to provide some scripts to automate running the
+[ovn-scale-test][1] test suite. The goal is for this to be integrated
+into a CI/CD system.
+
+Howto
+-----
+
+Running this project is as simple as the following:
+
+* Look at the ovn-scale.conf file for variable you can override to
+  change the runtime behaviour.
+* Modify ansible/docker-ovn-hosts to match the IP addresses of the
+  hosts you are using.
+* Run `prepare.sh` to prepare the system for running the scripts.
+* Run `scale-run.sh` to run the testsuite.
+* The script `scale-cleanup.sh` will cleanup all the containers.
+
+1: https://github.com/openvswitch/ovn-scale-test

--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -1,0 +1,41 @@
+---
+
+node_config_directory: "/etc/ovn-scale-test"
+ontainer_config_directory: "/var/lib/ovn-scale-test/config_files"
+
+###################
+# Docker options
+###################
+
+ovn_db_image: "huikang/ovn-scale-test-ovn-local-master"
+ovn_chassis_image: "huikang/ovn-scale-test-ovn-local-master"
+
+rally_image: "huikang/ovn-scale-test-rally-local-master"
+
+
+###################
+# Emulation options
+###################
+
+ovn_database_alias_ip: "172.16.20.100"
+ovn_database_device: "eth0"
+
+ovn_chassis_start_cidr: "172.16.200.10/16"
+ovn_chassis_device: "eth0"
+
+# Total number of emulated chassis
+ovn_number_chassis: 5
+
+
+########################
+# Rally workload options
+########################
+network_start_cidr: "172.16.201.0/24"
+network_number: "5"
+ports_per_network: "1"
+
+################
+# OVS Repository
+################
+ovs_repo: "https://github.com/openvswitch/ovs.git"
+ovs_branch: "master"

--- a/ci/ansible/docker-ovn-hosts-example
+++ b/ci/ansible/docker-ovn-hosts-example
@@ -1,0 +1,11 @@
+# You should only add one IP address in this role. The node in this role runs
+# the OVN databse container
+[ovn-control]
+REPLACE_IP
+
+# Add host IPs to run emulated OVN chassis
+[emulation-hosts]
+REPLACE_IP      provider_ip=REPLACE_IP
+
+[rally]
+REPLACE_IP

--- a/ci/docker-rally.sh
+++ b/ci/docker-rally.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+OVS_REPO=${1:-https://github.com/openvswitch/ovs.git}
+OVS_BRANCH=${2:-master}
+
+# A combined script to run all the things
+
+# Prepare the environment
+./prepare.sh
+
+# Run the testsuite
+./scale-run.sh $OVS_REPO $OVS_BRANCH
+
+# Clean things up
+./scale-cleanup.sh

--- a/ci/ovn-scale.conf
+++ b/ci/ovn-scale.conf
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This file contains the variables used by all the other
+# scripts.
+
+CUR_DIR=$(pwd)
+OVN_DOCKER_ROOT=${OVN_DOCKER_ROOT:-~/ovn-docker}
+OVN_RALLY_HOSTNAME=${OVN_RALLY_HOSTNAME:-$(hostname)}
+
+OVN_SCALE_REPO=${OVN_SCALE_REPO:-https://github.com/openvswitch/ovn-scale-test.git}
+OVN_SCALE_REPO_NAME=$(basename ${OVN_SCALE_REPO} | cut -f1 -d'.')
+OVN_SCALE_BRANCH=${OVN_SCALE_BRANCH:-origin/master}
+
+# The hosts file to use
+OVN_DOCKER_HOSTS=${OVN_DOCKER_HOSTS:-$CUR_DIR/ansible/docker-ovn-hosts}
+OVN_DOCKER_VARS=${OVN_DOCKER_VARS:-$CUR_DIR/ansible/all.yml}

--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Read variables
+source ovn-scale.conf
+
+# Install prerequisites
+sudo apt-get install -y apt-transport-https ca-certificates
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+if [ ! -f /etc/apt/sources.list.d/docker.list ] ; then
+    sudo su -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list' 
+    sudo apt-get update -y
+    sudo apt-get purge -y lxc-docker 
+    sudo apt-get install -y apparmor
+fi
+
+# Setup ssh
+if [ ! -f ~/.ssh/id_rsa.pub ] ; then
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
+fi
+
+# Add public key to authorized_keys
+OVNKEY="$(cat ~/.ssh/id_rsa.pub | cut -d " " -f 2)"
+OVNKEYTHERE=$(grep $OVNKEY ~/.ssh/authorized_keys)
+if [ "$OVNKEYTHERE" == "" ] ; then
+    cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+fi
+
+# Setup ssh
+sudo su root <<'EOF'
+if [ ! -f /root/.ssh/id_rsa.pub ] ; then
+    ssh-keygen -t rsa -f /root/.ssh/id_rsa -N ''
+fi
+EOF
+
+# Add public key to authorized_keys
+sudo su -m root <<'EOF'
+OVNKEY="$(cat /root/.ssh/id_rsa.pub | cut -d " " -f 2)"
+OVNKEYTHERE=$(grep $OVNKEY $HOME/.ssh/authorized_keys)
+if [ "$OVNKEYTHERE" == "" ] ; then
+    cat /root/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
+EOF
+
+# Install the docker engine
+sudo apt-get install -y docker-engine
+sudo service docker start
+
+# Create a docker group and add ubuntu user to this group
+EXISTING_DOCKER=$(cat /etc/group | grep docker)
+if [ "$EXISTING_DOCKER" == "" ]; then
+    sudo groupadd docker
+    sudo usermod -aG docker ubuntu
+    echo "WARNING: The docker group was created and the ubuntu user added to this group."
+    echo "         Please reboot the box, log back in, and re-run $0."
+    exit 1
+fi
+
+# Install python dependencies
+sudo apt-get install -y python-pip
+sudo pip install --upgrade pip
+sudo pip install -U docker-py netaddr
+sudo apt-get remove -y ansible
+sudo pip install ansible==2.0.2.0
+
+# Prepate the docker-ovn-hosts file
+LOCALIP=$(ifconfig eth0|grep 'inet ' | sed -e 's/ \+/ /g' | cut -d " " -f 3 | cut -d ":" -f 2)
+
+cat ansible/docker-ovn-hosts-example | sed -e "s/REPLACE_IP/$LOCALIP/g" > ansible/docker-ovn-hosts

--- a/ci/scale-cleanup.sh
+++ b/ci/scale-cleanup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Read variables
+source ovn-scale.conf
+
+pushd $OVN_DOCKER_ROOT
+
+# Clean everything up
+pushd $OVN_SCALE_REPO_NAME
+sudo /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS -e action=clean
+popd
+docker rmi ovn-scale-test-ovn
+docker rmi ovn-scale-test-base
+# Find the <none> image and delete it
+docker rmi $(docker images | grep none | awk -F' +' '{print $3}')
+
+popd

--- a/ci/scale-run.sh
+++ b/ci/scale-run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Read variables
+source ovn-scale.conf
+
+OVS_REPO=$1
+OVS_BRANCH=$2
+
+mkdir -p $OVN_DOCKER_ROOT
+pushd $OVN_DOCKER_ROOT
+
+# Install OVN Scale Test
+if [ ! -d $OVN_SCALE_REPO_NAME ]; then
+    git clone $OVN_SCALE_REPO
+    pushd $OVN_SCALE_REPO_NAME
+    git fetch
+    git checkout $OVN_SCALE_BRANCH
+    popd
+fi
+
+# Build the docker containers
+pushd $OVN_SCALE_REPO_NAME
+cd ansible/docker
+make
+popd
+
+# Deploy the containers
+# TODO(mestery): Loop through all hosts in the "[emulation-hosts]" section.
+#                For now, this assumes a single host, so not necessary until
+#                that assumption changes.
+pushd $OVN_SCALE_REPO_NAME
+sudo /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS \
+     --extra-vars "ovs_repo=$OVS_REPO" --extra-vars "ovs_branch=$OVS_BRANCH" -e action=deploy
+popd
+
+# Verify the containers are running
+# TODO(mestery): Actually verify everything is connected
+docker exec ovn-south-database ovn-sbctl show
+
+# Create the rally deployment
+docker exec ovn-rally rally-ovs deployment create --file /root/rally-ovn/ovn-multihost-deployment.json --name ovn-multihost
+
+# Register the emulated sandboxes in the rally database
+docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create-sandbox-$OVN_RALLY_HOSTNAME.json
+TASKID=$(docker exec ovn-rally rally task list --uuids-only)
+docker exec ovn-rally rally task report $TASKID --out /root/create-sandbox-output.html
+docker cp ovn-rally:/root/create-sandbox-output.html .
+docker exec ovn-rally rally task delete --uuid $TASKID
+
+# Run tests
+docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create_networks.json
+TASKID=$(docker exec ovn-rally rally task list --uuids-only)
+docker exec ovn-rally rally task report $TASKID --out /root/create-networks-output.html
+docker cp ovn-rally:/root/create-networks-output.html .
+docker exec ovn-rally rally task delete --uuid $TASKID
+
+docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create_and_list_lports.json
+TASKID=$(docker exec ovn-rally rally task list --uuids-only)
+docker exec ovn-rally rally task report $TASKID --out /root/create-and-list-lports-output.html
+docker cp ovn-rally:/root/create-and-list-lports-output.html .
+docker exec ovn-rally rally task delete --uuid $TASKID
+
+docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create_and_bind_ports.json
+TASKID=$(docker exec ovn-rally rally task list --uuids-only)
+docker exec ovn-rally rally task report $TASKID --out /root/create-and-bind-ports-output.html
+docker cp ovn-rally:/root/create-and-bind-ports-output.html .
+docker exec ovn-rally rally task delete --uuid $TASKID
+
+popd


### PR DESCRIPTION
This commit adds some wrapper scripts around the ovn-scale-test ansible which
are meant to be used for integration with a continuous integration system.

Signed-off-by: Kyle Mestery mestery@mestery.com
