### PR TITLE
Cleanup the CI/CD scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ site.retry
 
 # generated ci/ansible/docker-ovn-hosts file
 ci/ansible/docker-ovn-hosts
+
+# The generated HTML files
+ci/*.html

--- a/ci/ovn-scale.conf
+++ b/ci/ovn-scale.conf
@@ -4,12 +4,8 @@
 # scripts.
 
 CUR_DIR=$(pwd)
-OVN_DOCKER_ROOT=${OVN_DOCKER_ROOT:-~/ovn-docker}
 OVN_RALLY_HOSTNAME=${OVN_RALLY_HOSTNAME:-$(hostname)}
-
-OVN_SCALE_REPO=${OVN_SCALE_REPO:-https://github.com/openvswitch/ovn-scale-test.git}
-OVN_SCALE_REPO_NAME=$(basename ${OVN_SCALE_REPO} | cut -f1 -d'.')
-OVN_SCALE_BRANCH=${OVN_SCALE_BRANCH:-origin/master}
+OVN_SCALE_TOP=$CUR_DIR/../
 
 # The hosts file to use
 OVN_DOCKER_HOSTS=${OVN_DOCKER_HOSTS:-$CUR_DIR/ansible/docker-ovn-hosts}

--- a/ci/scale-cleanup.sh
+++ b/ci/scale-cleanup.sh
@@ -3,15 +3,11 @@
 # Read variables
 source ovn-scale.conf
 
-pushd $OVN_DOCKER_ROOT
-
 # Clean everything up
-pushd $OVN_SCALE_REPO_NAME
+pushd $OVN_SCALE_TOP
 sudo /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS -e action=clean
 popd
 docker rmi ovn-scale-test-ovn
 docker rmi ovn-scale-test-base
 # Find the <none> image and delete it
 docker rmi $(docker images | grep none | awk -F' +' '{print $3}')
-
-popd

--- a/ci/scale-run.sh
+++ b/ci/scale-run.sh
@@ -6,20 +6,8 @@ source ovn-scale.conf
 OVS_REPO=$1
 OVS_BRANCH=$2
 
-mkdir -p $OVN_DOCKER_ROOT
-pushd $OVN_DOCKER_ROOT
-
-# Install OVN Scale Test
-if [ ! -d $OVN_SCALE_REPO_NAME ]; then
-    git clone $OVN_SCALE_REPO
-    pushd $OVN_SCALE_REPO_NAME
-    git fetch
-    git checkout $OVN_SCALE_BRANCH
-    popd
-fi
-
 # Build the docker containers
-pushd $OVN_SCALE_REPO_NAME
+pushd $OVN_SCALE_TOP
 cd ansible/docker
 make
 popd
@@ -28,7 +16,7 @@ popd
 # TODO(mestery): Loop through all hosts in the "[emulation-hosts]" section.
 #                For now, this assumes a single host, so not necessary until
 #                that assumption changes.
-pushd $OVN_SCALE_REPO_NAME
+pushd $OVN_SCALE_TOP
 sudo /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS \
      --extra-vars "ovs_repo=$OVS_REPO" --extra-vars "ovs_branch=$OVS_BRANCH" -e action=deploy
 popd
@@ -65,5 +53,3 @@ TASKID=$(docker exec ovn-rally rally task list --uuids-only)
 docker exec ovn-rally rally task report $TASKID --out /root/create-and-bind-ports-output.html
 docker cp ovn-rally:/root/create-and-bind-ports-output.html .
 docker exec ovn-rally rally task delete --uuid $TASKID
-
-popd


### PR DESCRIPTION
This cleans things up such that we no longer clone the ovn-scale-test
repository (this code now lives in this repository). We also no longer
create a top-level directory but simply run from the ci directory.

Signed-off-by: Kyle Mestery mestery@mestery.com
