### PR TITLE
Use $OVNSUDO when building docker containers in ansible

### DIFF
--- a/ansible/docker/base/Makefile
+++ b/ansible/docker/base/Makefile
@@ -1,4 +1,4 @@
 image_name=ovn-scale-test-base
 
 image:
-	docker build --force-rm=true -t ${image_name} .
+	${OVNSUDO} docker build --force-rm=true -t ${image_name} .

--- a/ansible/docker/ovn/Makefile
+++ b/ansible/docker/ovn/Makefile
@@ -1,4 +1,4 @@
 image_name=ovn-scale-test-ovn
 
 image:
-	docker build --build-arg ovs_repo={{ ovs_repo}} --build-arg ovs_branch={{ ovs_branch }} --force-rm=true -t ${image_name} .
+	${OVNSUDO} docker build --build-arg ovs_repo={{ ovs_repo}} --build-arg ovs_branch={{ ovs_branch }} --force-rm=true -t ${image_name} .

--- a/ansible/docker/rally/Makefile
+++ b/ansible/docker/rally/Makefile
@@ -1,4 +1,4 @@
 image_name=huikang/ovn-scale-test-rally
 
 image:
-	docker build --force-rm=true -t ${image_name} .
+	${OVNSUDO} docker build --force-rm=true -t ${image_name} .


### PR DESCRIPTION
This is needed when running on hosts where the user running the scripts does
not have access to the docker daemon.

Signed-off-by: Kyle Mestery mestery@mestery.com
