### PR TITLE
Fix spelling error

### DIFF
--- a/ansible/etc/variables.yml
+++ b/ansible/etc/variables.yml
@@ -1,7 +1,7 @@
 ---
 
 node_config_directory: "/etc/ovn-scale-test"
-ontainer_config_directory: "/var/lib/ovn-scale-test/config_files"
+container_config_directory: "/var/lib/ovn-scale-test/config_files"
 
 ###################
 # Docker options

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,7 +1,7 @@
 ---
 
 node_config_directory: "/etc/ovn-scale-test"
-ontainer_config_directory: "/var/lib/ovn-scale-test/config_files"
+container_config_directory: "/var/lib/ovn-scale-test/config_files"
 
 deploy_user: "rally"
 

--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -1,7 +1,7 @@
 ---
 
 node_config_directory: "/etc/ovn-scale-test"
-ontainer_config_directory: "/var/lib/ovn-scale-test/config_files"
+container_config_directory: "/var/lib/ovn-scale-test/config_files"
 
 ###################
 # Docker options


### PR DESCRIPTION
Correct the spelling of "container_config_directory" everywhere.

Signed-off-by: Kyle Mestery mestery@mestery.com
