### PR TITLE
In travis-ci, use docker image built during CI process

### DIFF
--- a/ansible/docker/rally/Dockerfile
+++ b/ansible/docker/rally/Dockerfile
@@ -21,8 +21,10 @@ RUN cd rally_ovn_scale_test \
     && ./install_rally.sh
 
 # Install OVN scale test plugin for rally
-RUN git clone https://github.com/openvswitch/ovn-scale-test.git
+# TODO (huikang): switch to upstream repo after this PR merged
+RUN git clone https://github.com/huikang/ovn-scale-test.git
 RUN cd ovn-scale-test \
+    && git checkout ci-images \
     && ./install.sh
 
 RUN mkdir /var/run/sshd

--- a/ansible/docker/rally/Makefile
+++ b/ansible/docker/rally/Makefile
@@ -1,4 +1,4 @@
-image_name=huikang/ovn-scale-test-rally
+image_name=ovn-scale-test-rally
 
 image:
 	${OVNSUDO} docker build --force-rm=true -t ${image_name} .

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -14,6 +14,8 @@ ovn_chassis_image: "huikang/ovn-scale-test-ovn"
 
 rally_image: "huikang/ovn-scale-test-rally"
 
+# Valid options are [ missing, always ]
+image_pull_policy: "always"
 
 ###################
 # Emulation options

--- a/ansible/roles/ovn/tasks/clean.yml
+++ b/ansible/roles/ovn/tasks/clean.yml
@@ -3,7 +3,7 @@
   docker:
     name: "{{ item }}"
     image: "{{ ovn_db_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     state: absent
   with_items:
     - "ovn-north-database"
@@ -21,7 +21,7 @@
   docker:
     name: "sandbox-{{ item.1 }}"
     image: "{{ ovn_db_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     privileged: yes
     net: host
     detach: True

--- a/ansible/roles/ovn/tasks/config.yml
+++ b/ansible/roles/ovn/tasks/config.yml
@@ -41,14 +41,17 @@
   when:
     - inventory_hostname in groups['emulation-hosts']
 
-- name: Create user on all hosts
+- name: Create user "{{ deploy_user }}" on all hosts
   user:
     name: "{{ deploy_user }}"
     generate_ssh_key: yes
     ssh_key_file: .ssh/id_rsa
+  when: deploy_user != 'root'
 
 - name: Copy authorized keys to user
   command: "cp -f /root/.ssh/authorized_keys /home/{{ deploy_user }}/.ssh/"
+  when: deploy_user != 'root'
 
 - name: Change ownership for authorized keys
   command: "chown -R {{ deploy_user }} /home/{{ deploy_user }}/.ssh"
+  when: deploy_user != 'root'

--- a/ansible/roles/ovn/tasks/start.yml
+++ b/ansible/roles/ovn/tasks/start.yml
@@ -8,7 +8,7 @@
   docker:
     name: ovn-north-database
     image: "{{ ovn_db_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     privileged: yes
     net: host
     detach: True
@@ -24,7 +24,7 @@
   docker:
     name: ovn-south-database
     image: "{{ ovn_db_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     privileged: yes
     net: host
     detach: True
@@ -40,7 +40,7 @@
   docker:
     name: ovn-northd
     image: "{{ ovn_db_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     privileged: yes
     net: host
     detach: True
@@ -56,7 +56,7 @@
   docker:
     name: "sandbox-{{ item.1 }}"
     image: "{{ ovn_db_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     privileged: yes
     net: host
     detach: True

--- a/ansible/roles/rally/tasks/start.yml
+++ b/ansible/roles/rally/tasks/start.yml
@@ -3,7 +3,7 @@
   docker:
     name: ovn-rally
     image: "{{ rally_image_full }}"
-    pull: always
+    pull: "{{ image_pull_policy }}"
     privileged: yes
     detach: True
     state: started

--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -3,15 +3,19 @@
 node_config_directory: "/etc/ovn-scale-test"
 container_config_directory: "/var/lib/ovn-scale-test/config_files"
 
+deploy_user: "root"
+
 ###################
 # Docker options
 ###################
 
-ovn_db_image: "huikang/ovn-scale-test-ovn-local-master"
-ovn_chassis_image: "huikang/ovn-scale-test-ovn-local-master"
+ovn_db_image: "ovn-scale-test-ovn"
+ovn_chassis_image: "ovn-scale-test-ovn"
 
-rally_image: "huikang/ovn-scale-test-rally-local-master"
+rally_image: "ovn-scale-test-rally"
 
+# Valid options are [ missing, always ]
+image_pull_policy: "missing"
 
 ###################
 # Emulation options

--- a/ci/scale-run.sh
+++ b/ci/scale-run.sh
@@ -15,13 +15,14 @@ pushd $OVN_SCALE_TOP
 cd ansible/docker
 make ovsrepo=$OVS_REPO ovsbranch=$OVS_BRANCH
 popd
+$OVNSUDO docker images
 
 # Deploy the containers
 # TODO(mestery): Loop through all hosts in the "[emulation-hosts]" section.
 #                For now, this assumes a single host, so not necessary until
 #                that assumption changes.
 pushd $OVN_SCALE_TOP
-sudo /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS \
+$OVNSUDO /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS \
      --extra-vars "ovs_repo=$OVS_REPO" --extra-vars "ovs_branch=$OVS_BRANCH" -e action=deploy
 if [ "$?" != "0" ] ; then
     echo "Deploying failed, exiting"
@@ -61,6 +62,8 @@ TASKID=$($OVNSUDO docker exec ovn-rally rally task list --uuids-only)
 $OVNSUDO docker exec ovn-rally rally task report $TASKID --out /root/create-and-bind-ports-output.html
 $OVNSUDO docker cp ovn-rally:/root/create-and-bind-ports-output.html .
 $OVNSUDO docker exec ovn-rally rally task delete --uuid $TASKID
+
+$OVNSUDO docker ps
 
 # Restore xtrace
 $XTRACE

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -91,34 +91,34 @@ class OvnNbctl(OvsClient):
             params = [name]
 
 
-            self.run("lswitch-add", args=params)
+            self.run("ls-add", args=params)
 
             return {"name":name}
 
         def lswitch_del(self, name):
             params = [name]
-            self.run("lswitch-del", args=params)
+            self.run("ls-del", args=params)
 
 
 
         def lswitch_list(self):
-            self.run("lswitch-list")
+            self.run("ls-list")
 
         def lport_add(self, lswitch, name):
             params =[lswitch, name]
-            self.run("lport-add", args=params)
+            self.run("lsp-add", args=params)
 
             return {"name":name}
 
 
         def lport_list(self, lswitch):
             params =[lswitch]
-            self.run("lport-list", args=params)
+            self.run("lsp-list", args=params)
 
 
         def lport_del(self, name):
             params = [name]
-            self.run("lport-del", args=params)
+            self.run("lsp-del", args=params)
 
         '''
         param address: [mac,ip], [mac] ...
@@ -129,24 +129,24 @@ class OvnNbctl(OvsClient):
             for i in addresses:
                 params += ["\ ".join(i)]
 
-            self.run("lport-set-addresses", args=params)
+            self.run("lsp-set-addresses", args=params)
 
 
         def lport_set_port_security(self, name, *addresses):
             params = [name]
             params += addresses
-            self.run("lport-set-port-security", args=params)
+            self.run("lsp-set-port-security", args=params)
 
 
         def lport_set_type(self, name, type):
             params = [name, type]
-            self.run("lport-set-type", args=params)
+            self.run("lsp-set-type", args=params)
 
 
         def lport_set_options(self, name, *options):
             params = [name]
             params += options
-            self.run("lport-set-options", args=params)
+            self.run("lsp-set-options", args=params)
 
         def acl_add(self, lswitch, direction, priority, match, action,
                     log=False):

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -298,7 +298,7 @@ class OvnScenario(scenario.OvsScenario):
         ovn_nbctl.enable_batch_mode(True)
 
         for lport in lports:
-            ovn_nbctl.wait_until('Logical_Port', lport["name"], ('up', 'true'))
+            ovn_nbctl.wait_until('Logical_Switch_Port', lport["name"], ('up', 'true'))
 
         ovn_nbctl.flush()
 


### PR DESCRIPTION
Add varialbe image_pull_policy to control whether pulling image
from dockerhub

Signed-off-by: Hui Kang kangh@us.ibm.com
