### PR TITLE
Fix ovn-rally cleanup task

### DIFF
--- a/ansible/roles/ovn/tasks/clean.yml
+++ b/ansible/roles/ovn/tasks/clean.yml
@@ -56,3 +56,4 @@
     state: absent
     remove: yes
     move_home: yes
+  when: deploy_user != 'root'


### PR DESCRIPTION
If deployer user is root, we do not need to remove the user

Signed-off-by: Hui Kang kangh@us.ibm.com
