### PR TITLE
Correct return's from non-functions to be exits

### DIFF
--- a/ci/scale-run.sh
+++ b/ci/scale-run.sh
@@ -21,7 +21,7 @@ function check_container_failure {
         for failed in ${failed_containers}; do
             docker logs --tail all ${failed}
         done
-        return 1
+        exit 1
     fi
 }
 
@@ -41,7 +41,7 @@ $OVNSUDO /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -
      --extra-vars "ovs_repo=$OVS_REPO" --extra-vars "ovs_branch=$OVS_BRANCH" --extra-vars "config_flag=$CONFIG_FLAG" -e action=deploy
 if [ "$?" != "0" ] ; then
     echo "Deploying failed, exiting"
-    return 1
+    exit 1
 fi
 popd
 


### PR DESCRIPTION
Commit 3a2272f1148dd8cac3d387c061c3143dd639cb17 added some error handling,
and also changed some "exit" values to "return" values in scale-run.sh.
However, since those were being done outside a funciton, this resulted
in incorrect bash syntax as below:

Deploying failed, exiting
- return 1
  ./scale-run.sh: line 44: return: can only `return' from a function or sourced script
- popd

This commits changes the "return" values back to "exit" values.

Signed-off-by: Kyle Mestery mestery@mestery.com
