### PR TITLE
Update docker image names in ci

### DIFF
--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -9,10 +9,10 @@ deploy_user: "root"
 # Docker options
 ###################
 
-ovn_db_image: "ovn-scale-test-ovn"
-ovn_chassis_image: "ovn-scale-test-ovn"
+ovn_db_image: "huikang/ovn-scale-test-ovn"
+ovn_chassis_image: "huikang/ovn-scale-test-ovn"
 
-rally_image: "ovn-scale-test-rally"
+rally_image: "huikang/ovn-scale-test-rally"
 
 # Valid options are [ missing, always ]
 image_pull_policy: "missing"


### PR DESCRIPTION
It's unclear how this used to work, but a recent issue arose (see
Isse #74) where running ovn-scale-test using the CI scripts was
failing. This was tracked down to incorrect docker image names.

Closes Issue #74

Signed-off-by: Kyle Mestery mestery@mestery.com
