### PR TITLE
Actually test real scale in create_and_bind_ports

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -41,6 +41,7 @@ northd_cpu_set: ""
 network_start_cidr: "172.16.201.0/24"
 network_number: "5"
 ports_per_network: "1"
+ports_created_batch_size: "1"
 
 acls_per_port: "1"
 

--- a/ansible/roles/rally/templates/create_and_bind_ports.json.j2
+++ b/ansible/roles/rally/templates/create_and_bind_ports.json.j2
@@ -13,7 +13,7 @@
                     "physical_network": "providernet"
                 },
                 "port_create_args" : {
-                    "batch": 1
+                    "batch": {{ port_created_batch_size }}
                 },
                 "ports_per_network": {{ ports_per_network }},
                 "port_bind_args": {

--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -36,7 +36,8 @@ ovn_number_chassis: 5
 ########################
 network_start_cidr: "172.16.201.0/24"
 network_number: "5"
-ports_per_network: "50"
+ports_per_network: "500"
+ports_create_batch_size: "50"
 acls_per_port: "5"
 
 ################


### PR DESCRIPTION
Add ability to change port create batch size and
set it to 50 for ci.  Update ports_per_network to 500.

Signed-off-by: Ryan Moats rmoats@us.ibm.com
