### PR TITLE
copy ovn-scale-test to ovn-rally container from local directory

### DIFF
--- a/ansible/docker/rally/Dockerfile
+++ b/ansible/docker/rally/Dockerfile
@@ -21,7 +21,7 @@ RUN cd rally_ovn_scale_test \
     && ./install_rally.sh
 
 # Install OVN scale test plugin for rally
-RUN git clone https://github.com/openvswitch/ovn-scale-test.git
+COPY ovn-scale-test ovn-scale-test
 RUN cd ovn-scale-test \
     && ./install.sh
 

--- a/ansible/docker/rally/Makefile
+++ b/ansible/docker/rally/Makefile
@@ -1,4 +1,7 @@
 image_name=ovn-scale-test-rally
 
 image:
+	tar cvzf /tmp/ovn-scale-test.tgz ../../../../ovn-scale-test
+	tar xvzf /tmp/ovn-scale-test.tgz
 	${OVNSUDO} docker build --force-rm=true -t ${image_name} .
+	rm -rf ./ovn-scale-test


### PR DESCRIPTION
Without this patch, change to rally_ovs will not effect in the
travis-ci

Signed-off-by: Hui Kang kangh@us.ibm.com
