### PR TITLE
Ensure prepare.sh works for hosts with a bond interface

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -90,6 +90,10 @@ else
     fi
 fi
 LOCALIP=$(ip addr show dev eth0 | grep 'inet ' | cut -d " " -f 6 | cut -d "/" -f 1)
+if [ "$LOCALIP" == "" ] ; then
+    # Try bond0
+    LOCALIP=$(ip addr show dev bond0 | grep 'inet ' | cut -d " " -f 6 | cut -d "/" -f 1)
+fi
 LRT=$(grep "Match host $LOCALIP" /etc/ssh/sshd_config)
 if [ "$LRT" == "" ] ; then
     echo "Match host $LOCALIP" >> /etc/ssh/sshd_config


### PR DESCRIPTION
Found while testing in SoftLayer, where physical hosts have bonds
instead of individual network interfaces.

Signed-off-by: Kyle Mestery mestery@mestery.com
