### PR TITLE
Fix rally_ovs workload in ci job

### DIFF
--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -36,8 +36,8 @@ ovn_number_chassis: 5
 ########################
 network_start_cidr: "172.16.201.0/24"
 network_number: "5"
-ports_per_network: "500"
-ports_created_batch_size: "50"
+ports_per_network: "10"
+ports_created_batch_size: "1"
 acls_per_port: "5"
 
 ################


### PR DESCRIPTION
- ci has logical network as IP/24, the lport number must < 256
- lport_bind operation does not support batch size > 1 now in
  container-based deployment
- Reduce the lport in the ci job as we do not run real scale test
  on travis-ci VMs

Signed-off-by: Hui Kang kangh@us.ibm.com
