### PR TITLE
Batch more operations

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -42,6 +42,7 @@ network_start_cidr: "172.16.201.0/24"
 network_number: "5"
 ports_per_network: "1"
 ports_created_batch_size: "1"
+networks_created_batch_size: "1"
 
 acls_per_port: "1"
 

--- a/ansible/roles/rally/templates/create_and_bind_ports.json.j2
+++ b/ansible/roles/rally/templates/create_and_bind_ports.json.j2
@@ -8,7 +8,7 @@
             "args": {
                 "network_create_args": {
                     "amount": {{ network_number }},
-                    "batch": 1,
+                    "batch": {{ networks_created_batch_size }},
                     "start_cidr": "{{ network_start_cidr }}",
                     "physical_network": "providernet"
                 },

--- a/ansible/roles/rally/templates/create_and_list_acls.json.j2
+++ b/ansible/roles/rally/templates/create_and_list_acls.json.j2
@@ -8,12 +8,12 @@
             "args": {
                 "lswitch_create_args": {
                     "amount": {{ network_number }},
-                    "batch": 1,
+                    "batch": {{ networks_created_batch_size }},
                     "start_cidr": "{{ network_start_cidr }}",
                     "physical_network": "providernet"
                 },
                 "lport_create_args" : {
-                    "batch": 1
+                    "batch": {{ ports_created_batch_size }}
                 },
                 "lports_per_lswitch": {{ ports_per_network }},
                 "acl_create_args" : {

--- a/ci/ansible/all.yml
+++ b/ci/ansible/all.yml
@@ -21,7 +21,7 @@ image_pull_policy: "missing"
 # Emulation options
 ###################
 
-ovn_database_alias_ip: "172.16.20.100"
+ovn_database_alias_ip: "172.16.20.100/16"
 ovn_database_device: "eth0"
 
 ovn_chassis_start_cidr: "172.16.200.10/16"
@@ -38,6 +38,7 @@ network_start_cidr: "172.16.201.0/24"
 network_number: "5"
 ports_per_network: "10"
 ports_created_batch_size: "1"
+networks_created_batch_size: "1"
 acls_per_port: "5"
 
 ################


### PR DESCRIPTION
Batch operations to create networks and lswitches, as well as ports
in the ACL test.

Also correct the assignment of  ovn_database_alias_ip in the ci
all.yml file.

Signed-off-by: Kyle Mestery mestery@mestery.com
