### PR TITLE
Support running the CI environment with multiple hosts

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -15,7 +15,8 @@ Running this project is as simple as the following:
 * Modify ansible/docker-ovn-hosts to match the IP addresses of the
   hosts you are using.
 * Run `prepare.sh` to prepare the system for running the scripts.
-* Run `scale-run.sh` to run the testsuite.
+* Run `scale-hosts.sh` to create the docker containers on each host.
+* Run `scale-test.sh` to run the testsuite.
 * The script `scale-cleanup.sh` will cleanup all the containers.
 
 1: https://github.com/openvswitch/ovn-scale-test

--- a/ci/docker-rally.sh
+++ b/ci/docker-rally.sh
@@ -21,8 +21,11 @@ echo "OVS_REPO=${OVS_REPO} OVS_BRANCH=${OVS_BRANCH} CONFIG_FLAGS=${CONFIG_FLAGS}
 # resave trace setting
 set -o xtrace
 
+# Create the docker containers
+./scale-hosts.sh $OVS_REPO $OVS_BRANCH $CONFIG_FLAGS || FAILED=$(( $FAILED + 1 ))
+
 # Run the testsuite
-./scale-run.sh $OVS_REPO $OVS_BRANCH $CONFIG_FLAGS || FAILED=$(( $FAILED + 1 ))
+./scale-test.sh
 
 # Clean things up
 ./scale-cleanup.sh || FAILED=$(( $FAILED + 1 ))

--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -132,5 +132,11 @@ if [ "$INSTALLDOCKER" == "True" ] ; then
     fi
 fi
 
+# Increase maxkeys, see Docker PR here:
+# https://github.com/cloudfoundry/bosh/issues/1340
+$OVNSUDO sysctl -w kernel/keys/root_maxkeys=10000000
+$OVNSUDO sysctl -w kernel/keys/maxkeys=10000000
+$OVNSUDO /etc/init.d/docker restart
+
 # Restore xtrace
 $XTRACE

--- a/ci/scale-cleanup.sh
+++ b/ci/scale-cleanup.sh
@@ -7,6 +7,13 @@ set -o xtrace
 # Read variables
 source ovn-scale.conf
 
+# Blow away the cache directories. This can cause painful bleeding from the
+# eyes when trying to debug why a changed rally config isn't taking place
+# in your ovn-rally container, only to realise it's due to this directory
+# effectively being a cache which is retained.
+CACHEDIR=$(grep node_config_directory $CUR_DIR/ansible/all.yml | cut -d " " -f 2 | sed -e 's/\"//g')
+sudo rm -rf $CACHEDIR
+
 # Clean everything up
 pushd $OVN_SCALE_TOP
 sudo /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS -e action=clean

--- a/ci/scale-hosts.sh
+++ b/ci/scale-hosts.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Save trace setting
+XTRACE=$(set +o | grep xtrace)
+set -o xtrace
+
+# Read variables
+source ovn-scale.conf
+
+OVS_REPO=$1
+OVS_BRANCH=$2
+CONFIG_FLAGS=$3
+
+function check_container_failure {
+    sleep 5
+
+    docker ps -a
+    failed_containers=$(docker ps -a --format "{{.Names}}" --filter status=exited)
+
+    if [ "$failed_containers" ]; then
+        for failed in ${failed_containers}; do
+            docker logs --tail all ${failed}
+        done
+        exit 1
+    fi
+}
+
+function check_ovn_rally {
+    output_file=$1
+    count=`cat $output_file | grep total | grep 100 | wc -l`
+    if [ $count -ne 0 ]
+    then
+        echo "Rally run succeeded"
+    else
+        echo "Rally run failed"
+        exit 1
+    fi
+}
+
+# Build the docker containers
+pushd $OVN_SCALE_TOP
+cd ansible/docker
+make ovsrepo=$OVS_REPO ovsbranch=$OVS_BRANCH configflags=$CONFIG_FLAGS
+popd
+$OVNSUDO docker images
+
+# Deploy the containers
+pushd $OVN_SCALE_TOP
+$OVNSUDO /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS \
+     --extra-vars "ovs_repo=$OVS_REPO" --extra-vars "ovs_branch=$OVS_BRANCH" --extra-vars "configflags=$CONFIG_FLAGS" -e action=deploy
+if [ "$?" != "0" ] ; then
+    echo "Deploying failed, exiting"
+    exit 1
+fi
+popd
+
+# Verify the containers are running
+check_container_failure
+
+# TODO(mestery): Verifying everything is connected
+$OVNSUDO docker exec ovn-south-database ovn-sbctl show
+
+# Create the rally deployment
+$OVNSUDO docker exec ovn-rally rally-ovs deployment create --file /root/rally-ovn/ovn-multihost-deployment.json --name ovn-multihost
+
+# Restore xtrace
+$XTRACE

--- a/ci/scale-test.sh
+++ b/ci/scale-test.sh
@@ -7,24 +7,6 @@ set -o xtrace
 # Read variables
 source ovn-scale.conf
 
-OVS_REPO=$1
-OVS_BRANCH=$2
-CONFIG_FLAGS=$3
-
-function check_container_failure {
-    sleep 5
-
-    docker ps -a
-    failed_containers=$(docker ps -a --format "{{.Names}}" --filter status=exited)
-
-    if [ "$failed_containers" ]; then
-        for failed in ${failed_containers}; do
-            docker logs --tail all ${failed}
-        done
-        exit 1
-    fi
-}
-
 function check_ovn_rally {
     output_file=$1
     count=`cat $output_file | grep total | grep 100 | wc -l`
@@ -37,42 +19,16 @@ function check_ovn_rally {
     fi
 }
 
-# Build the docker containers
-pushd $OVN_SCALE_TOP
-cd ansible/docker
-make ovsrepo=$OVS_REPO ovsbranch=$OVS_BRANCH configflags=$CONFIG_FLAGS
-popd
-$OVNSUDO docker images
-
-# Deploy the containers
-# TODO(mestery): Loop through all hosts in the "[emulation-hosts]" section.
-#                For now, this assumes a single host, so not necessary until
-#                that assumption changes.
-pushd $OVN_SCALE_TOP
-$OVNSUDO /usr/local/bin/ansible-playbook -i $OVN_DOCKER_HOSTS ansible/site.yml -e @$OVN_DOCKER_VARS \
-     --extra-vars "ovs_repo=$OVS_REPO" --extra-vars "ovs_branch=$OVS_BRANCH" --extra-vars "configflags=$CONFIG_FLAGS" -e action=deploy
-if [ "$?" != "0" ] ; then
-    echo "Deploying failed, exiting"
-    exit 1
-fi
-popd
-
-# Verify the containers are running
-check_container_failure
-
-# TODO(mestery): Verifying everything is connected
-$OVNSUDO docker exec ovn-south-database ovn-sbctl show
-
-# Create the rally deployment
-$OVNSUDO docker exec ovn-rally rally-ovs deployment create --file /root/rally-ovn/ovn-multihost-deployment.json --name ovn-multihost
-
 # Register the emulated sandboxes in the rally database
-$OVNSUDO docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create-sandbox-$OVN_RALLY_HOSTNAME.json 2>&1 | tee /tmp/rally-ovs-output.raw
-check_ovn_rally /tmp/rally-ovs-output.raw
-TASKID=$($OVNSUDO docker exec ovn-rally rally task list --uuids-only)
-$OVNSUDO docker exec ovn-rally rally task report $TASKID --out /root/create-sandbox-output.html
-$OVNSUDO docker cp ovn-rally:/root/create-sandbox-output.html .
-$OVNSUDO docker exec ovn-rally rally task delete --uuid $TASKID
+SANDBOXHOSTS=$($OVNSUDO docker exec ovn-rally ls root/rally-ovn/workload/ | grep create-sandbox-)
+for sand in $SANDBOXHOSTS ; do
+    $OVNSUDO docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/$sand 2>&1 | tee /tmp/rally-ovs-output.raw
+    check_ovn_rally /tmp/rally-ovs-output.raw
+    TASKID=$($OVNSUDO docker exec ovn-rally rally task list --uuids-only)
+    $OVNSUDO docker exec ovn-rally rally task report $TASKID --out /root/create-sandbox-output.html
+    $OVNSUDO docker cp ovn-rally:/root/create-sandbox-output.html .
+    #$OVNSUDO docker exec ovn-rally rally task delete --uuid $TASKID
+done
 
 # Run tests
 $OVNSUDO docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create_networks.json 2>&1 | tee /tmp/rally-ovs-output.raw


### PR DESCRIPTION
This commit adds support for running the CI environment with multiple
physical hosts, allowing the system to spread containers across the
physical hosts, and ultimately achieving a higher level of scale than
possible on a single physical host.

Closes issue #92.

Signed-off-by: Kyle Mestery mestery@mestery.com
