### PR TITLE
Remove OVS DB files before creating them

### DIFF
--- a/ansible/docker/ovn/ovn-sandbox-chassis.sh
+++ b/ansible/docker/ovn/ovn-sandbox-chassis.sh
@@ -172,6 +172,7 @@ function start_ovs {
     OVSDB_REMOTE=""
 
     touch "$sandbox"/.conf.db.~lock~
+    rm -f conf.db
     run ovsdb-tool create conf.db "$schema"
 
     run ovsdb-server --detach --no-chdir --pidfile \

--- a/ansible/docker/ovn/ovn-sandbox-database.sh
+++ b/ansible/docker/ovn/ovn-sandbox-database.sh
@@ -156,6 +156,7 @@ function start_ovs {
 
     touch "$sandbox"/.conf-nb.db.~lock~
     touch "$sandbox"/.conf-sb.db.~lock~
+    rm -f conf-nb.db conf-sb.db
     run ovsdb-tool create conf-nb.db "$schema"
     run ovsdb-tool create conf-sb.db "$schema"
 

--- a/ansible/docker/ovn/ovn-sandbox-north-ovsdb.sh
+++ b/ansible/docker/ovn/ovn-sandbox-north-ovsdb.sh
@@ -156,6 +156,7 @@ function start_ovs {
 
     touch "$sandbox"/.conf-nb.db.~lock~
 
+    rm -f conf-nb.db
     run ovsdb-tool create conf-nb.db "$schema"
 
 

--- a/ansible/docker/ovn/ovn-sandbox-south-ovsdb.sh
+++ b/ansible/docker/ovn/ovn-sandbox-south-ovsdb.sh
@@ -156,6 +156,7 @@ function start_ovs {
 
     touch "$sandbox"/.conf-sb.db.~lock~
 
+    rm -f conf-sb.db
     run ovsdb-tool create conf-sb.db "$schema"
 
     touch "$sandbox"/.ovnsb.db.~lock~

--- a/rally_ovs/plugins/ovs/deployment/engines/ovs/ovs-sandbox.sh
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovs/ovs-sandbox.sh
@@ -629,11 +629,13 @@ function start_ovs {
 
             touch "$sandbox"/.conf-nb.db.~lock~
             touch "$sandbox"/.conf-sb.db.~lock~
+            rm -f conf-nb.db conf-sb.db
             run ovsdb-tool create conf-nb.db "$schema"
             run ovsdb-tool create conf-sb.db "$schema"
 
             touch "$sandbox"/.ovnsb.db.~lock~
             touch "$sandbox"/.ovnnb.db.~lock~
+            rm -f ovnsb.db ovnnb.db
             run ovsdb-tool create ovnsb.db "$ovnsb_schema"
             run ovsdb-tool create ovnnb.db "$ovnnb_schema"
 
@@ -676,6 +678,7 @@ EOF
         fi
     else
         touch "$sandbox"/.conf.db.~lock~
+        rm -f conf.db
         run ovsdb-tool create conf.db "$schema"
 
         run_service ovsdb-server ovsdb-server --detach --no-chdir --pidfile \


### PR DESCRIPTION
I have been running into errors where creation of the various OVS databases
was failing due to them already existing. To get around this, ensure they
are deleted before we try and create them.

Signed-off-by: Kyle Mestery mestery@mestery.com
