### PR TITLE
Change the log file path of ovn-northd

### DIFF
--- a/ansible/docker/ovn/ovn-sandbox-northd.sh
+++ b/ansible/docker/ovn/ovn-sandbox-northd.sh
@@ -171,6 +171,7 @@ function start_ovn {
 
     run ovn-northd  --no-chdir --pidfile \
               -vconsole:off -vsyslog:off -vfile:info --log-file \
+              --log-file=/usr/local/var/run/openvswitch/ovn-northd.log \
               --ovnnb-db=unix:/usr/local/var/run/openvswitch/ovnnb_db.sock \
               --ovnsb-db=unix:/usr/local/var/run/openvswitch/ovnsb_db.sock
 }


### PR DESCRIPTION
Like ovnsdb north and south db process, we want to persist the
log file of ovn-northd in the docker host.

Signed-off-by: Hui Kang kangh@us.ibm.com
