### PR TITLE
Initialize north and south db

### DIFF
--- a/ansible/docker/ovn/ovn-sandbox-northd.sh
+++ b/ansible/docker/ovn/ovn-sandbox-northd.sh
@@ -169,6 +169,9 @@ function start_ovs {
 function start_ovn {
     echo "Starting OVN northd"
 
+    ovn-nbctl init
+    ovn-sbctl init
+
     run ovn-northd  --no-chdir --pidfile \
               -vconsole:off -vsyslog:off -vfile:info --log-file \
               --ovnnb-db=unix:/usr/local/var/run/openvswitch/ovnnb_db.sock \


### PR DESCRIPTION
Particularly initialize NB_Global and SB_Global tables, whcih is
used by --wait of ovn-nbctl.

Signed-off-by: Hui Kang kangh@us.ibm.com
