### PR TITLE
Enhance ci/prepare.sh when appending to /etc/ssh/sshd_config

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -106,6 +106,9 @@ if [ "$LOCALIP" == "" ] ; then
     PHYS_DEV=$(ip route list match 0.0.0.0/0 | grep -oP "(?<=dev )[^\s]*(?=\s)")
     LOCALIP=$(ip -4 addr show $PHYS_DEV | grep -oP "(?<=inet ).*(?=/)")
 fi
+# add new line to the end of /etc/ssh/sshd_config, if needed.
+# Failure to do so will cause config to smudge that line
+[[ $(tail -c1 /etc/ssh/sshd_config | wc -l) == 1 ]] || echo >> /etc/ssh/sshd_config
 LRT=$(grep "Match host $LOCALIP" /etc/ssh/sshd_config)
 if [ "$LRT" == "" ] ; then
     echo "Match host $LOCALIP" >> /etc/ssh/sshd_config


### PR DESCRIPTION
The file /etc/ssh/sshd_config -- from official trusty vagrant box --
is not terminated with the end-of-line character.

By appending to that file, the "UsePAM yes" config gets corrupted
and subsequent ssh access starts to fail.

With this change -- if needed -- a new line will be added to that
file before any potential append takes place.

   # diff orig/ssh/sshd_config /etc/ssh/sshd_config
   88c88,91
   < UsePAM yes
   \ No newline at end of file

---

> UsePAM yesMatch host 10.0.2.15
>     PermitRootLogin without-password

Signed-off-by: Flavio Fernandes flavio@flaviof.com
