### PR TITLE
Use ovn-nbctl --wait=hv sync to get end-to-end port binding time

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -175,6 +175,17 @@ class OvnNbctl(OvsClient):
 
             return get_lswitch_info(output)
 
+        def sync(self, wait='hv'):
+            # sync command should always be flushed
+            opts = ["--wait=%s" % wait]
+            batch_mode = self.batch_mode
+            if batch_mode:
+                self.flush()
+                self.batch_mode = False
+
+            self.run("sync", opts)
+            self.batch_mode = batch_mode
+
     def create_client(self):
         print "*********   call OvnNbctl.create_client"
 

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -57,12 +57,14 @@ class OvnNbctl(OvsClient):
                 return
 
             if self.sandbox:
+                cmd_prefix = []
                 if self.install_method == "sandbox":
                     self.cmds.append(". %s/sandbox.rc" % self.sandbox)
-                    cmd = itertools.chain(["ovn-nbctl"], opts, [cmd], args)
-                    self.cmds.append(" ".join(cmd))
                 elif self.install_method == "docker":
-                    self.cmds.append("sudo docker exec ovn-north-database ovn-nbctl " + cmd + " " + " ".join(args))
+                    cmd_prefix = ["sudo docker exec ovn-north-database"]
+
+                cmd = itertools.chain(cmd_prefix, ["ovn-nbctl"], opts, [cmd], args)
+                self.cmds.append(" ".join(cmd))
 
             self.ssh.run("\n".join(self.cmds),
                          stdout=stdout, stderr=stderr)

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -263,6 +263,13 @@ class OvnScenario(scenario.OvsScenario):
     def _bind_ports(self, lports, sandboxes, port_bind_args):
         port_bind_args = port_bind_args or {}
         wait_up = port_bind_args.get("wait_up", False)
+        # "wait_sync" takes effect only if wait_up is True.
+        # By default we wait for all HVs catching up with the change.
+        wait_sync = port_bind_args.get("wait_sync", "hv")
+        if wait_sync.lower() not in ['hv', 'sb', 'none']:
+            raise exceptions.InvalidConfigException(_(
+                "Unknown value for wait_sync: %s. "
+                "Only 'hv', 'sb' and 'none' are allowed.") % wait_sync)
 
         sandbox_num = len(sandboxes)
         lport_num = len(lports)
@@ -294,12 +301,12 @@ class OvnScenario(scenario.OvsScenario):
             j += 1
 
         if wait_up:
-            self._wait_up_port(lports, install_method)
+            self._wait_up_port(lports, wait_sync, install_method)
 
 
     @atomic.action_timer("ovn_network.wait_port_up")
-    def _wait_up_port(self, lports, install_method):
-        LOG.info("wait port up" )
+    def _wait_up_port(self, lports, wait_sync, install_method):
+        LOG.info("wait port up. sync: %s" % wait_sync)
         ovn_nbctl = self.controller_client("ovn-nbctl")
         ovn_nbctl.set_sandbox("controller-sandbox", install_method)
         ovn_nbctl.enable_batch_mode(True)
@@ -307,8 +314,8 @@ class OvnScenario(scenario.OvsScenario):
         for lport in lports:
             ovn_nbctl.wait_until('Logical_Switch_Port', lport["name"], ('up', 'true'))
 
-        ovn_nbctl.flush()
-
+        if wait_sync != "none":
+            ovn_nbctl.sync(wait_sync)
 
 
 


### PR DESCRIPTION
Currently the scale testing waits port state UP in ovn-nb and then
starts next round of port creation and binding. This is inaccurate,
because when CPU is 100% in test farms it can't reflect the real
time that ovn-controllers spent to complete each round of processing.

With the new feature "--wait=hv" [1], and the follow-up "sync" cmd
support [2], we can now wait for the port bindings to be processed
and reflected on all HVs before starting next round, so that the real
processing time can be reflected and evaluate more accurately the
related scalability improvements.

[1] https://github.com/openvswitch/ovs/commit/fa183acc654f7e5da17cd70fc91d6b5b02782183
[2] https://github.com/openvswitch/ovs/commit/de32cec780e8d2a4358075c2449858247881f266
