### PR TITLE
Fix warning: use file module with owner instead of chown

### DIFF
--- a/ansible/roles/ovn/tasks/config.yml
+++ b/ansible/roles/ovn/tasks/config.yml
@@ -53,5 +53,9 @@
   when: deploy_user != 'root'
 
 - name: Change ownership for authorized keys
-  command: "chown -R {{ deploy_user }} /home/{{ deploy_user }}/.ssh"
+  file:
+    path: "/home/{{ deploy_user }}/.ssh"
+    state: "directory"
+    recurse: yes
+    owner: "{{ deploy_user }}"
   when: deploy_user != 'root'


### PR DESCRIPTION
Replace command with file modules, to address the following warning
in ansible/roles/ovn/tasks/config.yml:

 [WARNING]: Consider using file module with owner rather than running chown
