### PR TITLE
Allow skip of ovn-scale-test-rally docker image creation

### DIFF
--- a/ansible/docker/Makefile
+++ b/ansible/docker/Makefile
@@ -1,4 +1,8 @@
-SUBDIRS = base ovn rally
+ifneq (,$(findstring yes,$(NO_RALLY)))
+	SUBDIRS = base ovn
+else
+	SUBDIRS = base ovn rally
+endif
 
 subdirs:
 	for dir in $(SUBDIRS); do \

--- a/ci/scale-pure-ovn-hosts.sh
+++ b/ci/scale-pure-ovn-hosts.sh
@@ -17,7 +17,7 @@ CONFIG_FLAGS=$3
 # Build the docker containers
 pushd $OVN_SCALE_TOP
 cd ansible/docker
-make ovsrepo=$OVS_REPO ovsbranch=$OVS_BRANCH configflags=$CONFIG_FLAGS
+NO_RALLY=yes make ovsrepo=$OVS_REPO ovsbranch=$OVS_BRANCH configflags=$CONFIG_FLAGS
 popd
 $OVNSUDO docker images
 


### PR DESCRIPTION
By providing "NO_RALLY=yes" to ansible/docker/Makefile,
the scale-pure-ovn can now explictly skip the creation
of the docker image for rally
