### PR TITLE
Add batch processing variable for network creation

### DIFF
--- a/ansible/roles/rally/templates/create_networks.json.j2
+++ b/ansible/roles/rally/templates/create_networks.json.j2
@@ -11,7 +11,8 @@
                 "network_create_args": {
                     "amount": {{ network_number }},
                     "start_cidr": "{{ network_start_cidr }}",
-                    "physical_network": "providernet"
+                    "physical_network": "providernet",
+                    "batch": {{ networks_created_batch_size }}
                 }
             },
             "runner": {"type": "serial", "times": 1},


### PR DESCRIPTION
Without this, you cannot create more than 500 networks or so, as we exceed
the command line length.

Signed-off-by: Kyle Mestery mestery@mestery.com
