### PR TITLE
Add creating and binding port for logical router task

### DIFF
--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -301,6 +301,13 @@ in the rally container.
    rally-ovs task start /root/rally-ovn/workload/create_routers.json
 
 
+- Create routers and ports connect to the routers
+
+::
+
+   rally-ovs task start /root/rally-ovn/workload/create_routers_bind_ports.json
+
+
 To clean up the emulation environment, run
 
 ::

--- a/ansible/roles/rally/tasks/config.yml
+++ b/ansible/roles/rally/tasks/config.yml
@@ -52,6 +52,7 @@
     - "create_networks"
     - "create_and_list_acls"
     - "create_routers"
+    - "create_routers_bind_ports"
 
 - name: Copying over create-sandbox file on farm node
   template:

--- a/ansible/roles/rally/templates/create_routers_bind_ports.json.j2
+++ b/ansible/roles/rally/templates/create_routers_bind_ports.json.j2
@@ -1,0 +1,38 @@
+{
+    "version": 2,
+    "title": "Create OVN logical routers",
+    "subtasks": [{
+        "title": "Create OVN logical routers",
+        "workloads": [{
+            "name": "OvnNetwork.create_routers_bind_ports",
+            "args": {
+                "router_create_args": {
+                    "amount": {{ router_number }},
+                    "batch": {{ routers_create_batch_size }},
+                },
+                "router_connection_method": {{ router_connection_method }},
+                "networks_per_router": {{ networks_per_router }},
+                "network_create_args": {
+                    "batch": {{ networks_created_batch_size }},
+                    "start_cidr": "{{ network_start_cidr }}",
+                    "physical_network": "providernet"
+                },
+                "port_create_args" : {
+                    "batch": {{ ports_created_batch_size }}
+                },
+                "ports_per_network": {{ ports_per_network }},
+                "port_bind_args": {
+                    "wait_up": true,
+                }
+            },
+            "runner": {
+                "type": "serial","times": 1},
+            "context": {
+               "ovn_multihost" : {
+                    "controller": "ovn-controller-node"
+                },
+                "sandbox":{ "tag": "ToR1"}
+            }
+        }]
+    }]
+}

--- a/ci/scale-test.sh
+++ b/ci/scale-test.sh
@@ -72,6 +72,16 @@ $OVNSUDO docker cp ovn-rally:/root/create-routers-output.html .
 $OVNSUDO docker exec ovn-rally rally task delete --uuid $TASKID
 $OVNSUDO rm -rf /tmp/rally-ovs-output.raw
 
+$OVNSUDO docker exec ovn-rally rally-ovs task start /root/rally-ovn/workload/create_routers_bind_ports.json 2>&1 | tee /tmp/rally-ovs-output.raw
+check_ovn_rally /tmp/rally-ovs-output.raw
+TASKID=$($OVNSUDO docker exec ovn-rally rally task list --uuids-only)
+# NOTE(mestery): HTML and JSON data are collected differently, look to consolidate
+$OVNSUDO docker exec ovn-rally rally task report $TASKID --out /root/create_routers_bind_ports-output.html
+$OVNSUDO docker exec ovn-rally rally task results $TASKID > ./create_routers_bind_ports-data.json
+$OVNSUDO docker cp ovn-rally:/root/create_routers_bind_ports-output.html .
+$OVNSUDO docker exec ovn-rally rally task delete --uuid $TASKID
+$OVNSUDO rm -rf /tmp/rally-ovs-output.raw
+
 $OVNSUDO docker ps
 
 # Restore xtrace

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -286,6 +286,19 @@ class OvnScenario(scenario.OvsScenario):
                          ('type', 'router'),
                          ('address', "\\"+"\""+mac+"\\"+"\""))
         ovn_nbctl.flush()
+
+    def _connect_networks_to_routers(self, lnetworks, lrouters, networks_per_router):
+        j = 0
+        for i in range(len(lrouters)):
+            lrouter = lrouters[i]
+            LOG.info("Connect %s networks to router %s" % (networks_per_router, lrouter["name"]))
+            for k in range(j, j+int(networks_per_router)):
+                lnetwork = lnetworks[k]
+                LOG.info("connect networks %s cidr %s" % (lnetwork["name"], lnetwork["cidr"]))
+                self._connect_network_to_router(lrouter, lnetwork)
+
+            j += int(networks_per_router)
+
   
     # NOTE(huikang): num_networks overides the "amount" in network_create_args
     @atomic.action_timer("ovn_network.create_network")


### PR DESCRIPTION
- this is a follow-up task for create_routers tasks
- create and bind ports for logical switches, which connect
  to the logical routers

Signed-off-by: Hui Kang kangh@us.ibm.com
