### PR TITLE
Fix rally-ovs repo path in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ PYTHON=${PYTHON2:-$PYTHON3}
 BASE_PIP_URL=${BASE_PIP_URL:-"https://pypi.python.org/simple"}
 VIRTUALENV_191_URL="https://raw.github.com/pypa/virtualenv/1.9.1/virtualenv.py"
 
-OVN_SCALE_TEST_GIT_URL="https://github.com/l8huang/rally-ovs.git"
+OVN_SCALE_TEST_GIT_URL="https://github.com/l8huang/rally.git"
 OVN_SCALE_TEST_GIT_BRANCH="master"
 RALLY_CONFIGURATION_DIR=/etc/rally
 


### PR DESCRIPTION
Fix the typo in the rally-ovs repo which is merged as rally in upstream to help avoid error while setting up ovn scale test environment.