### PR TITLE
Use 'router' as address for the lsp connected to logical router.

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -284,7 +284,7 @@ class OvnScenario(scenario.OvsScenario):
         ovn_nbctl.db_set('Logical_Switch_Port', switch_router_port,
                          ('options', {"router_port":network["name"]}),
                          ('type', 'router'),
-                         ('address', "\\"+"\""+mac+"\\"+"\""))
+                         ('address', 'router'))
         ovn_nbctl.flush()
 
     def _connect_networks_to_routers(self, lnetworks, lrouters, networks_per_router):


### PR DESCRIPTION
In history the mac of the lsp connected to logical router must be
the same as the mac of the peer logical router port, which is redundant.
Now that value 'router' is supported, we shall use it directly.