### PR TITLE
prepare.sh: Ignore the error from grep if the user cannot be found

### DIFF
--- a/rally_ovs/plugins/ovs/deployment/engines/ovs/prepare.sh
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovs/prepare.sh
@@ -7,7 +7,7 @@ OVS_USER=$1
 echo "Prepare user $OVS_USER for ovs deployment"
 
 # Check for an existing user
-_USER=$(grep $OVS_USER /etc/passwd)
+_USER=$(grep $OVS_USER /etc/passwd || true)
 if [ "$_USER" == "" ]; then
     useradd $OVS_USER -m || echo "Error adding user $OVS_USER" >&2
     mkdir -m 700 /home/$OVS_USER/.ssh || true


### PR DESCRIPTION
Otherwise the non-zero exit status from a subshell will cause the script to fail which is not what we want since we expect that the user might not exist yet.