### PR TITLE
Re-use existing lswitches when new computes are added:

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -101,6 +101,11 @@ def get_lswitch_info(info):
 
     return lswitches
 
+def parse_lswitch_list(lswitch_data):
+    lswitches = []
+    for line in lswitch_data.splitlines():
+        lswitches.append({"name": line.split(" ")[1].strip('()')})
+    return lswitches
 
 def set_colval_args(*col_values):
     args = []

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import pipes
 import sys
 import itertools
 import pipes
@@ -122,9 +121,11 @@ class OvnNbctl(OvsClient):
             self.run("ls-del", args=params)
 
 
-
         def lswitch_list(self):
-            self.run("ls-list")
+            stdout = StringIO()
+            self.run("ls-list", stdout=stdout)
+            output = stdout.getvalue()
+            return parse_lswitch_list(output)
 
         def lswitch_port_add(self, lswitch, name):
             params =[lswitch, name]

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -82,7 +82,7 @@ class OvnScenario(scenario.OvsScenario):
         ovn_nbctl = self.controller_client("ovn-nbctl")
         ovn_nbctl.set_sandbox("controller-sandbox")
         ovn_nbctl.enable_batch_mode(False)
-        ovn_nbctl.lswitch_list()
+        return ovn_nbctl.lswitch_list()
 
     @atomic.action_timer("ovn.delete_lswitch")
     def _delete_lswitch(self, lswitches):


### PR DESCRIPTION
1. No need to create LRs and LS when computes get added; instead create lports in the same LRs and LS and bind them to the computes.
2. Make sure to pass the sandbox tag to load all new Sandboxes of that farm.
3. Add use_existing_routers flag to load existing northd data.