### PR TITLE
Fix parser for ovn-nbctl show command output

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -91,11 +91,11 @@ def get_lswitch_info(info):
     lswitch = None
     for line in info.splitlines():
         tokens = line.strip().split(" ")
-        if tokens[0] == "lswitch":
+        if tokens[0] == "switch":
             name = tokens[2][1:-1]
             lswitch = {"name":name, "uuid":tokens[1], "lports":[]}
             lswitches.append(lswitch)
-        elif tokens[0] == "lport":
+        elif tokens[0] == "port":
             name = tokens[1][1:-1]
             lswitch["lports"].append({"name":name})
 


### PR DESCRIPTION
Since openvswitch v2.6.0 output format of `ovn-nbctl show` has
changed. Any occurrences of "lswitch" have been replaced with "switch",
and occurrences of "lport" have replaced with just "port". Adapt to
the changes.

Ideally we shouldn't be doing output scraping if output format is
free-form but instead ask for machine readable output like JSON or
CSV.