### PR TITLE
Correct timer name for list ports action in OvnScenario

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -166,7 +166,7 @@ class OvnScenario(scenario.OvsScenario):
         ovn_nbctl.flush()
 
 
-    @atomic.action_timer("ovn.action_timer")
+    @atomic.action_timer("ovn.list_lports")
     def _list_lports(self, lswitches, install_method = "sandbox"):
         print("list lports")
         ovn_nbctl = self.controller_client("ovn-nbctl")


### PR DESCRIPTION
Timer name doesn't correspond to action name. Fix it.