### PR TITLE
Don't fail if the start CIDR was not given when creating an lswitch

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -63,7 +63,7 @@ class OvnScenario(scenario.OvsScenario):
                 lswitch["cidr"] = start_cidr.next(i)
 
             LOG.info("create %(name)s %(cidr)s" % \
-                      {"name": name, "cidr":lswitch["cidr"]})
+                      {"name": name, "cidr": lswitch.get("cidr", "")})
             lswitches.append(lswitch)
 
             flush_count -= 1


### PR DESCRIPTION
"cidr" key will be missing if start_cidr was not provided. Handle it.