### PR TITLE
Set lport address correctly when MAC or IP address is empty

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -143,13 +143,16 @@ class OvnNbctl(OvsClient):
             self.run("lsp-del", args=params)
 
         '''
-        param address: [mac,ip], [mac] ...
+        param address: [mac], [mac,ip], [mac,ip1,ip2] ...
         '''
         def lport_set_addresses(self, name, *addresses):
             params = [name]
 
             for i in addresses:
-                params += ["\ ".join(i)]
+                i = filter(lambda x: x, i)
+                i = "\ ".join(i)
+                if i:
+                    params += [i]
 
             self.run("lsp-set-addresses", args=params)
 


### PR DESCRIPTION
Passing an empty ("") IP address to OvnNbctl.lport_set_addresses(),
which is what we do in OvnScenario._create_lports(), results in an
invalid address string (i.e. there is a trailing space) being passed to
ovn-nbctl. This is not the expected behavior and it also triggers a
warning in the ovn-northd logs:

2018-03-06T16:14:48.111Z|00007|ovn_util|INFO|invalid syntax '28:82:41:16:5f:ae ' in address

Generate the address string correctly by checking if MAC and IP
addresses were given and that they are not empty.