### PR TITLE
tox: Add support for running flake8 linter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,7 @@ commands =
   find . -type f -name "*.pyc" -delete
   py.test --html=pytest_results.html --durations=10 "rally_ovs/tests/unit" {posargs}
 basepython = python2.7
+
+[testenv:pep8]
+commands = flake8 {posargs}
+distribute = false


### PR DESCRIPTION
Not added to the list of test environments run by default yet because we
have a lot errors. Can be run for selected files or directories with:
```
  $ tox -e pep8 -- <path>
```