### PR TITLE
Datapath context

### DIFF
--- a/rally_ovs/plugins/ovs/context/datapath.py
+++ b/rally_ovs/plugins/ovs/context/datapath.py
@@ -1,0 +1,70 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# TODO(jkbs):
+# - Use constants for order
+# - Require ovn_multihost context when common validators are available
+
+from rally import consts
+from rally.common import logging
+from rally.task import context
+
+from rally_ovs.plugins.ovs import ovnclients
+
+
+LOG = logging.getLogger(__name__)
+
+
+@context.configure(name="datapath", order=115)
+class Datapath(ovnclients.OvnClientMixin, context.Context):
+    """Create datapath resources.
+
+    This context creates logical routers.
+    """
+
+    CONFIG_SCHEMA = {
+        "type": "object",
+        "$schema": consts.JSON_SCHEMA,
+        "properties": {
+            "router_create_args": {
+                "type": "object",
+                "properties": {
+                    "amount": {"type": "integer", "minimum": 0},
+                    "batch": {"type": "integer", "minimum": 1},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "additionalProperties": False,
+    }
+
+    DEFAULT_CONFIG = {
+        "router_create_args": {"amount": 0},
+    }
+
+    def setup(self):
+        super(Datapath, self).setup()
+
+        router_create_args = self.config["router_create_args"]
+
+        routers = []
+        if router_create_args["amount"]:
+            routers = self._create_routers(router_create_args)
+
+        self.context["datapaths"] = {
+            "routers": routers,
+        }
+
+    def cleanup(self):
+        pass  # Not implemented

--- a/rally_ovs/plugins/ovs/context/datapath.py
+++ b/rally_ovs/plugins/ovs/context/datapath.py
@@ -30,7 +30,8 @@ LOG = logging.getLogger(__name__)
 class Datapath(ovnclients.OvnClientMixin, context.Context):
     """Create datapath resources.
 
-    This context creates logical routers.
+    This context creates datapath resources, like logical routers or logical
+    switches.
     """
 
     CONFIG_SCHEMA = {
@@ -45,25 +46,41 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
                 },
                 "additionalProperties": False,
             },
+            "lswitch_create_args": {
+                "type": "object",
+                "properties": {
+                    "amount": {"type": "integer", "minimum": 0},
+                    "batch": {"type": "integer", "minimum": 1},
+                    "start_cidr": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
         },
         "additionalProperties": False,
     }
 
     DEFAULT_CONFIG = {
         "router_create_args": {"amount": 0},
+        "lswitch_create_args": {"amount": 0},
     }
 
     def setup(self):
         super(Datapath, self).setup()
 
         router_create_args = self.config["router_create_args"]
+        lswitch_create_args = self.config["lswitch_create_args"]
 
         routers = []
         if router_create_args["amount"]:
             routers = self._create_routers(router_create_args)
 
+        lswitches = []
+        if lswitch_create_args["amount"]:
+            lswitches = self._create_lswitches(lswitch_create_args)
+
         self.context["datapaths"] = {
             "routers": routers,
+            "lswitches": lswitches,
         }
 
     def cleanup(self):

--- a/rally_ovs/plugins/ovs/context/datapath.py
+++ b/rally_ovs/plugins/ovs/context/datapath.py
@@ -31,7 +31,7 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
     """Create datapath resources.
 
     This context creates datapath resources, like logical routers or logical
-    switches.
+    switches, and optionally connects switches to routers.
     """
 
     CONFIG_SCHEMA = {
@@ -55,6 +55,7 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
                 },
                 "additionalProperties": False,
             },
+            "networks_per_router": {"type": "integer", "minimum": 0},
         },
         "additionalProperties": False,
     }
@@ -62,6 +63,7 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
     DEFAULT_CONFIG = {
         "router_create_args": {"amount": 0},
         "lswitch_create_args": {"amount": 0},
+        "networks_per_router": 0,
     }
 
     def setup(self):
@@ -69,6 +71,7 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
 
         router_create_args = self.config["router_create_args"]
         lswitch_create_args = self.config["lswitch_create_args"]
+        networks_per_router = self.config["networks_per_router"]
 
         routers = []
         if router_create_args["amount"]:
@@ -77,6 +80,10 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
         lswitches = []
         if lswitch_create_args["amount"]:
             lswitches = self._create_lswitches(lswitch_create_args)
+
+        if networks_per_router:
+            self._connect_networks_to_routers(lswitches, routers,
+                                              networks_per_router)
 
         self.context["datapaths"] = {
             "routers": routers,

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -120,13 +120,10 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         ovn_nbctl.flush()
 
     def _connect_networks_to_routers(self, lnetworks, lrouters, networks_per_router):
-        j = 0
-        for i in range(len(lrouters)):
-            lrouter = lrouters[i]
+        for lrouter in lrouters:
             LOG.info("Connect %s networks to router %s" % (networks_per_router, lrouter["name"]))
-            for k in range(j, j+int(networks_per_router)):
-                lnetwork = lnetworks[k]
+            for lnetwork in lnetworks[:networks_per_router]:
                 LOG.info("connect networks %s cidr %s" % (lnetwork["name"], lnetwork["cidr"]))
                 self._connect_network_to_router(lrouter, lnetwork)
 
-            j += int(networks_per_router)
+            lnetworks = lnetworks[networks_per_router:]

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+from rally.common import utils
+from rally_ovs.plugins.ovs import ovsclients
+
+
+class OvnClientMixin(ovsclients.ClientsMixin, utils.RandomNameGeneratorMixin):
+
+    def _create_routers(self, router_create_args):
+        self.RESOURCE_NAME_FORMAT = "lrouter_XXXXXX_XXXXXX"
+
+        amount = router_create_args.get("amount", 1)
+        batch = router_create_args.get("batch", 1)
+
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.enable_batch_mode()
+
+        flush_count = batch
+        lrouters = []
+
+        for i in range(amount):
+            name = self.generate_random_name()
+            lrouter = ovn_nbctl.lrouter_add(name)
+            lrouters.append(lrouter)
+
+            flush_count -= 1
+            if flush_count < 1:
+                ovn_nbctl.flush()
+                flush_count = batch
+
+        ovn_nbctl.flush() # ensure all commands be run
+        ovn_nbctl.enable_batch_mode(False)
+
+        return lrouters

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -12,12 +12,55 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import netaddr
 
+from rally.common import logging
 from rally.common import utils
 from rally_ovs.plugins.ovs import ovsclients
 
 
+LOG = logging.getLogger(__name__)
+
+
 class OvnClientMixin(ovsclients.ClientsMixin, utils.RandomNameGeneratorMixin):
+
+    def _create_lswitches(self, lswitch_create_args, num_switches=-1):
+        self.RESOURCE_NAME_FORMAT = "lswitch_XXXXXX_XXXXXX"
+
+        if (num_switches == -1):
+            num_switches = lswitch_create_args.get("amount", 1)
+        batch = lswitch_create_args.get("batch", num_switches)
+
+        start_cidr = lswitch_create_args.get("start_cidr", "")
+        if start_cidr:
+            start_cidr = netaddr.IPNetwork(start_cidr)
+
+        LOG.info("Create lswitches method: %s" % self.install_method)
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.enable_batch_mode()
+
+        flush_count = batch
+        lswitches = []
+        for i in range(num_switches):
+            name = self.generate_random_name()
+
+            lswitch = ovn_nbctl.lswitch_add(name)
+            if start_cidr:
+                lswitch["cidr"] = start_cidr.next(i)
+
+            LOG.info("create %(name)s %(cidr)s" % \
+                      {"name": name, "cidr": lswitch.get("cidr", "")})
+            lswitches.append(lswitch)
+
+            flush_count -= 1
+            if flush_count < 1:
+                ovn_nbctl.flush()
+                flush_count = batch
+
+        ovn_nbctl.flush() # ensure all commands be run
+        ovn_nbctl.enable_batch_mode(False)
+        return lswitches
 
     def _create_routers(self, router_create_args):
         self.RESOURCE_NAME_FORMAT = "lrouter_XXXXXX_XXXXXX"

--- a/rally_ovs/plugins/ovs/scenario.py
+++ b/rally_ovs/plugins/ovs/scenario.py
@@ -16,51 +16,11 @@
 import six
 
 from rally.task import scenario
-
-
 from rally_ovs.plugins.ovs import ovsclients
-from rally_ovs.plugins.ovs.consts import ResourceType
-from rally_ovs.plugins.ovs.utils import *
 
 
-class OvsScenario(scenario.Scenario):
+class OvsScenario(ovsclients.ClientsMixin, scenario.Scenario):
     """Base class for all OVS scenarios."""
-
 
     def __init__(self, context=None):
         super(OvsScenario, self).__init__(context)
-
-        multihost_info = context["ovn_multihost"]
-
-        for k,v in six.iteritems(multihost_info["controller"]):
-            cred = v["credential"]
-            self._controller_clients = ovsclients.Clients(cred)
-
-        self._farm_clients = {}
-        for k,v in six.iteritems(multihost_info["farms"]):
-            cred = v["credential"]
-            self._farm_clients[k] = ovsclients.Clients(cred)
-
-        self.install_method = multihost_info["install_method"]
-
-
-    def controller_client(self, client_type="ssh"):
-        client = getattr(self._controller_clients, client_type)
-        return client()
-
-
-    def farm_clients(self, name, client_type="ssh"):
-        clients = self._farm_clients[name]
-        client = getattr(clients, client_type)
-        return client()
-
-
-
-
-
-
-
-
-
-
-

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -33,46 +33,8 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
     '''
     @atomic.action_timer("ovn.create_lswitch")
     def _create_lswitches(self, lswitch_create_args, num_switches=-1):
-
         print("create lswitch")
-        self.RESOURCE_NAME_FORMAT = "lswitch_XXXXXX_XXXXXX"
-
-
-        if (num_switches == -1):
-            num_switches = lswitch_create_args.get("amount", 1)
-        batch = lswitch_create_args.get("batch", num_switches)
-
-        start_cidr = lswitch_create_args.get("start_cidr", "")
-        if start_cidr:
-            start_cidr = netaddr.IPNetwork(start_cidr)
-
-        LOG.info("Create lswitches method: %s" % self.install_method)
-        ovn_nbctl = self.controller_client("ovn-nbctl")
-        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
-        ovn_nbctl.enable_batch_mode()
-
-        flush_count = batch
-        lswitches = []
-        for i in range(num_switches):
-            name = self.generate_random_name()
-
-            lswitch = ovn_nbctl.lswitch_add(name)
-            if start_cidr:
-                lswitch["cidr"] = start_cidr.next(i)
-
-            LOG.info("create %(name)s %(cidr)s" % \
-                      {"name": name, "cidr": lswitch.get("cidr", "")})
-            lswitches.append(lswitch)
-
-            flush_count -= 1
-            if flush_count < 1:
-                ovn_nbctl.flush()
-                flush_count = batch
-
-        ovn_nbctl.flush() # ensure all commands be run
-        ovn_nbctl.enable_batch_mode(False)
-        return lswitches
-
+        return super(OvnScenario, self)._create_lswitches(lswitch_create_args, num_switches)
 
     @atomic.optional_action_timer("ovn.list_lswitch")
     def _list_lswitches(self):

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -194,45 +194,10 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         LOG.info("Create Logical routers")
         return super(OvnScenario, self)._create_routers(router_create_args)
 
-
-    def _connect_network_to_router(self, router, network):
-        LOG.info("Connect network %s to router %s" % (network["name"], router["name"]))
-
-        ovn_nbctl = self.controller_client("ovn-nbctl")
-        install_method = self.install_method
-        ovn_nbctl.set_sandbox("controller-sandbox", install_method)
-        ovn_nbctl.enable_batch_mode(False)
-
-
-        base_mac = [i[:2] for i in self.task["uuid"].split('-')]
-        base_mac[0] = str(hex(int(base_mac[0], 16) & 254))
-        base_mac[3:] = ['00']*3
-        mac = utils.get_random_mac(base_mac)
-
-        lrouter_port = ovn_nbctl.lrouter_port_add(router["name"], network["name"], mac,
-                                                  str(network["cidr"]))
-        ovn_nbctl.flush()
-
-
-        switch_router_port = "rp-" + network["name"]
-        lport = ovn_nbctl.lswitch_port_add(network["name"], switch_router_port)
-        ovn_nbctl.db_set('Logical_Switch_Port', switch_router_port,
-                         ('options', {"router-port":network["name"]}),
-                         ('type', 'router'),
-                         ('address', 'router'))
-        ovn_nbctl.flush()
-
     def _connect_networks_to_routers(self, lnetworks, lrouters, networks_per_router):
-        j = 0
-        for i in range(len(lrouters)):
-            lrouter = lrouters[i]
-            LOG.info("Connect %s networks to router %s" % (networks_per_router, lrouter["name"]))
-            for k in range(j, j+int(networks_per_router)):
-                lnetwork = lnetworks[k]
-                LOG.info("connect networks %s cidr %s" % (lnetwork["name"], lnetwork["cidr"]))
-                self._connect_network_to_router(lrouter, lnetwork)
-
-            j += int(networks_per_router)
+        super(OvnScenario, self)._connect_networks_to_routers(lnetworks,
+                                                              lrouters,
+                                                              networks_per_router)
 
     @atomic.action_timer("ovn_network.create_phynet")
     def _create_phynet(self, lswitches, physnet, batch):

--- a/rally_ovs/tests/unit/plugins/ovs/context/test_datapath.py
+++ b/rally_ovs/tests/unit/plugins/ovs/context/test_datapath.py
@@ -1,0 +1,104 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import itertools
+
+import mock
+from jsonschema.exceptions import ValidationError
+
+import ddt
+from rally_ovs.plugins.ovs.context.datapath import Datapath
+from rally_ovs.tests.unit.plugins.ovs import utils
+from tests.unit import test
+
+
+def gen_datapath_name(prefix, start=1):
+    n = itertools.count(start)
+    while True:
+        yield {"name": prefix + str(next(n))}
+
+
+@ddt.ddt
+class DatapathTestCase(test.TestCase):
+
+    @ddt.data({},
+              {"amount": 0},
+              {"amount": 1},
+              {"amount": 2},
+              {"amount": 0, "batch": 1},
+              {"amount": 1, "batch": 1},
+              {"amount": 2, "batch": 1},
+              {"amount": 2, "batch": 2})
+    def test_valid_router_config(self, router_create_args):
+        config = {"router_create_args": router_create_args}
+        Datapath.validate(config)
+
+    @ddt.data({"amount": -1},
+              {"amount": 0, "batch": 0},
+              {"amount": 1, "batch": -1})
+    def test_invalid_router_config(self, router_create_args):
+        config = {"router_create_args": router_create_args}
+        with self.assertRaisesRegexp(ValidationError, ""):  # Ignore message
+            Datapath.validate(config)
+
+    def test_setup_default(self):
+        context = utils.get_fake_context(datapath={})
+        dp_context = Datapath(context)
+        dp_context.setup()
+
+    @ddt.data({
+        "config": {
+            "router_create_args": {"amount": 1},
+        },
+        "datapaths": {
+            "routers": [
+                {"name": "lrouter_1"},
+            ],
+        },
+    }, {
+        "config": {
+            "router_create_args": {"amount": 2},
+        },
+        "datapaths": {
+            "routers": [
+                {"name": "lrouter_1"},
+                {"name": "lrouter_2"},
+            ],
+        },
+    }, {
+        "config": {
+            "router_create_args": {"amount": 3},
+        },
+        "datapaths": {
+            "routers": [
+                {"name": "lrouter_1"},
+                {"name": "lrouter_2"},
+                {"name": "lrouter_3"},
+            ],
+        },
+    })
+    @ddt.unpack
+    @mock.patch("rally_ovs.plugins.ovs.ovsclients_impl.OvnNbctl.create_client")
+    def test_only_routers(self, mock_create_client, config, datapaths):
+        mock_client = mock_create_client.return_value
+        mock_client.lrouter_add.side_effect = gen_datapath_name("lrouter_")
+
+        context = utils.get_fake_context(datapath=config)
+        dp_context = Datapath(context)
+        dp_context.setup()
+
+        expected_routers = datapaths["routers"]
+        actual_routers = dp_context.context["datapaths"]["routers"]
+        self.assertSequenceEqual(sorted(expected_routers),
+                                 sorted(actual_routers))

--- a/rally_ovs/tests/unit/plugins/ovs/context/test_datapath.py
+++ b/rally_ovs/tests/unit/plugins/ovs/context/test_datapath.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import collections
 import itertools
 
 import mock
@@ -202,3 +203,65 @@ class DatapathTestCase(test.TestCase):
         actual_lswitches = dp_context.context["datapaths"]["lswitches"]
         self.assertSequenceEqual(sorted(expected_lswitches),
                                  sorted(actual_lswitches))
+
+    @ddt.data({
+        "config": {
+            "router_create_args": {"amount": 1},
+            "lswitch_create_args": {"amount": 1, "start_cidr": "10.0.0.0/16"},
+            "networks_per_router": 1,
+        },
+    }, {
+        "config": {
+            "router_create_args": {"amount": 2},
+            "lswitch_create_args": {"amount": 4, "start_cidr": "10.0.0.0/16"},
+            "networks_per_router": 2,
+        },
+    }, {
+        "config": {
+            "router_create_args": {"amount": 2},
+            "lswitch_create_args": {"amount": 5, "start_cidr": "10.0.0.0/16"},
+            "networks_per_router": 3,
+        },
+    })
+    @ddt.unpack
+    @mock.patch("rally_ovs.plugins.ovs.ovsclients_impl.OvnNbctl.create_client")
+    def test_connected_lswitches_and_routers_port_count(self,
+                                                        mock_create_client,
+                                                        config):
+        mock_client = mock_create_client.return_value
+
+        mock_client.lrouter_add.side_effect = gen_datapath_name("lrouter_")
+        mock_client.lswitch_add.side_effect = gen_datapath_name("lswitch_")
+
+        router_port_count = collections.Counter()
+        switch_port_count = collections.Counter()
+
+        def fake_lrouter_port_add(name, *args, **kwargs):
+            router_port_count[name] += 1
+
+        def fake_lswitch_port_add(name, *args, **kwargs):
+            switch_port_count[name] += 1
+
+        mock_client.lrouter_port_add = fake_lrouter_port_add
+        mock_client.lswitch_port_add = fake_lswitch_port_add
+
+        context = utils.get_fake_context(datapath=config)
+        dp_context = Datapath(context)
+        dp_context.setup()
+
+        router_count = config["router_create_args"]["amount"]
+        switch_count = config["lswitch_create_args"]["amount"]
+        networks_per_router = config["networks_per_router"]
+
+        expected_router_port_count = [networks_per_router] * router_count
+        if switch_count % networks_per_router:
+            expected_router_port_count[0] = switch_count % networks_per_router
+        expected_switch_port_count = [1] * switch_count
+
+        actual_router_port_count = router_port_count.values()
+        actual_switch_port_count = switch_port_count.values()
+
+        self.assertSequenceEqual(sorted(expected_router_port_count),
+                                 sorted(actual_router_port_count))
+        self.assertSequenceEqual(sorted(expected_switch_port_count),
+                                 sorted(actual_switch_port_count))

--- a/rally_ovs/tests/unit/plugins/ovs/context/test_ovn_nb.py
+++ b/rally_ovs/tests/unit/plugins/ovs/context/test_ovn_nb.py
@@ -1,0 +1,45 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import mock
+
+from rally_ovs.plugins.ovs.context import ovn_nb
+from rally_ovs.tests.unit.plugins.ovs import utils
+from tests.unit import test
+
+class OvnNorthboundContextTestCase(test.TestCase):
+
+    @mock.patch("rally_ovs.plugins.ovs.ovsclients_impl.OvnNbctl.create_client")
+    def test_setup(self, mock_create_client):
+        ovn_nbctl_show_output = """\
+switch 48732e5d-b018-4bad-a1b6-8dbc762f4126 (lswitch_c52f4c_xFG42O)
+    port lport_c52f4c_LXzXCE
+    port lport_c52f4c_dkZSDg
+switch 7f55c582-c007-4fba-810d-a14ead480851 (lswitch_c52f4c_Rv0Jcj)
+    port lport_c52f4c_cm8SIf
+    port lport_c52f4c_8h7hn2
+switch 9fea76cf-d73e-4dc8-a2a3-1e98b9d8eab0 (lswitch_c52f4c_T0m6Ce)
+    port lport_c52f4c_X3px3u
+    port lport_c52f4c_92dhqb
+"""
+        mock_client = mock_create_client.return_value
+        mock_client.show.return_value = ovn_nbctl_show_output
+
+        context = utils.get_fake_context(ovn_nb={})
+        nb_context = ovn_nb.OvnNorthboundContext(context)
+        nb_context.setup()
+
+        expected_setup_output = ovn_nbctl_show_output
+        actual_setup_output = nb_context.context["ovn-nb"]
+        self.assertEqual(expected_setup_output, actual_setup_output)

--- a/rally_ovs/tests/unit/plugins/ovs/utils.py
+++ b/rally_ovs/tests/unit/plugins/ovs/utils.py
@@ -1,0 +1,47 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def get_fake_context(**config):
+    """Generates a fake context description for testing."""
+
+    fake_credential = {
+        "user": "fake_user",
+        "host": "fake_host",
+        "port": -1,
+        "key": "fake_key",
+        "password": "fake_password",
+    }
+
+    return {
+        "task": {
+            "uuid": "fake_task_uuid",
+        },
+        "ovn_multihost": {
+            "controller": {
+                "fake-controller-node": {
+                    "name": "fake-controller-node",
+                    "credential": fake_credential,
+                },
+            },
+            "farms": {
+                "fake-farm-node-0": {
+                    "name": "fake-farm-node-0",
+                    "credential": fake_credential,
+                },
+            },
+            "install_method": "fake_install_method",
+        },
+        "config": config,
+    }


### PR DESCRIPTION
These changes introduce a new context that can be used to pre-setup logical datapaths before the test run. It will create a given amount of logical routers, logical switches, and optionally connect the switches to the routers.

First we extract the code needed to create the routers, the switches, and connect them into a mixin, so that it can be shared between the scenarios and the contexts. Then the new context is added, with a minimal amount of code thanks to the extracted mixin.

We also add tests to cover the newly added context as well as the code moved around.