### PR TITLE
Add address-set support to ovn-scale-test framework

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -198,6 +198,24 @@ class DdCtlMixin(object):
         args += set_colval_args(*col_values)
         self.run("wait-until", args=args)
 
+    def create(self, table, record, *col_values):
+        args = [table, record]
+        args += set_colval_args(*col_values)
+        self.run("create", args=args)
+
+    def add(self, table, record, *col_values):
+        args = [table, record]
+        args += set_colval_args(*col_values)
+        self.run("add", args=args)
+
+    def set(self, table, record, *col_values):
+        args = [table, record]
+        args += set_colval_args(*col_values)
+        self.run("set", args=args)
+
+    def destroy(self, table, record):
+        args = [table, record]
+        self.run("destroy", args=args)
 
 
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -350,3 +350,41 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             "chart_plugin": "StackedArea", "data": oflow_data
         }
         self.add_output(additive_oflow_data)
+
+    def _create_address_set(self, set_name, address_list):
+        LOG.info("create %s address_set [%s]" % (set_name, address_list))
+
+        name = "name=\"" + set_name + "\""
+        addr_list="\"" + address_list + "\""
+
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.create("Address_Set", name, ('addresses', addr_list))
+        ovn_nbctl.flush()
+
+    def _address_set_add_addrs(self, set_name, address_list):
+        LOG.info("add [%s] to address_set %s" % (address_list, set_name))
+
+        name = "\"" + set_name + "\""
+        addr_list="\"" + address_list + "\""
+
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.add("Address_Set", name, ('addresses', ' ', addr_list))
+        ovn_nbctl.flush()
+
+    def _remove_address_set(self, set_name):
+        LOG.info("remove %s address_set" % set_name)
+
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.destroy("Address_Set", set_name)
+        ovn_nbctl.flush()
+
+    def _get_address_set(self, set_name):
+        LOG.info("get %s address_set" % set_name)
+
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.enable_batch_mode(False)
+        return ovn_nbctl.get("Address_Set", set_name, 'addresses')

--- a/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
@@ -147,5 +147,9 @@ class OvnNorthbound(ovn.OvnScenario):
 
         self._delete_acl(lswitches)
 
+    @scenario.configure(context={})
+    def create_and_remove_address_set(self, name, address_list):
+        self._create_address_set(name, address_list)
+        self._remove_address_set(name)
 
 


### PR DESCRIPTION
Introduce address-set support in ovn-scale-test framework in order to
properly simulate OpenShift workload where address-sets are referenced
in ingress ACL configuration (pod firewalling)