### PR TITLE
Redirect output of DdCtlMixin.get routine

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -18,6 +18,7 @@ import six
 
 from rally.common.plugin import plugin
 from utils import py_to_val
+from io import StringIO
 
 _NAMESPACE = "ovs"
 
@@ -135,8 +136,10 @@ class DdCtlMixin(object):
     def get(self, table, record, *col_values):
         args = [table, record]
         args += set_colval_args(*col_values)
-        self.run("get", args=args)
 
+        stdout = StringIO()
+        self.run("get", args=args, stdout=stdout)
+        return stdout.getvalue()
 
     def list(self, table, records):
         args = [table]


### PR DESCRIPTION
Redirect output of get DdCtlMixin.get routine from stdoutput to a
local variable