### PR TITLE
Fix DdCtlMixing.get() args parsing

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -135,7 +135,8 @@ class DdCtlMixin(object):
 
     def get(self, table, record, *col_values):
         args = [table, record]
-        args += set_colval_args(*col_values)
+        for entry in col_values:
+            args.append("%s" % entry)
 
         stdout = StringIO()
         self.run("get", args=args, stdout=stdout)


### PR DESCRIPTION
Do not use set_colval_args routine in DdCtlMixing.get() since 'ovn-nbctl
get' expects a list of column names, not a list of (column,
relational operator, value) tuples