### PR TITLE
Split timed operations up.

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn_network.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_network.py
@@ -76,7 +76,7 @@ class OvnNetwork(ovn.OvnScenario):
             lports = self._create_lports(network, port_create_args, ports_per_network)
             if (len(lports) < len(sandboxes)):
                 LOG.warn("Number of ports less than chassis: random binding\n")
-            self._bind_ports(lports, sandboxes, port_bind_args)
+            self._bind_ports_and_wait(lports, sandboxes, port_bind_args)
 
 
     @validation.number("ports_per_network", minval=1, integer_only=True)
@@ -105,7 +105,7 @@ class OvnNetwork(ovn.OvnScenario):
 
         for lswitch in lswitches:
             lports = self._create_lports(lswitch, port_create_args, ports_per_network)
-            self._bind_ports(lports, sandboxes, port_bind_args)
+            self._bind_ports_and_wait(lports, sandboxes, port_bind_args)
 
 
     def bind_ports(self):


### PR DESCRIPTION
The atomic action timer "ovn_network.bind_port" is used for the
_bind_port() member of OvnScenario. If the "wait_up" parameter is true,
then it calls into the wait_up_port() member, which has its own atomic
action timer "ovn_network.wait_port_up". The result of this is that
ovn_network.wait_port_up contributes towards the ovn_network.bind_port
timer.

This commit makes it so that the ovn_network.wait_port_up timer is not
part of the ovn_network.bind_port timer. This way, rally reports make it
more clear where time is being spent.