### PR TITLE
Adapt shell scripts for running over SSH without a pseduo-tty

### DIFF
--- a/rally_ovs/plugins/ovs/deployment/engines/ovs/install.sh
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovs/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Adjust PATH for non-interactive SSH sessions.
+export PATH=$PATH:/usr/local/sbin:/usr/sbin
+
 OVS_REPO=$1
 OVS_BRANCH=$2
 OVS_USER=$3

--- a/rally_ovs/plugins/ovs/deployment/engines/ovs/ovs-sandbox.sh
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovs/ovs-sandbox.sh
@@ -17,6 +17,9 @@
 #set -e # exit on first error
 #set -x
 
+# Adjust PATH for non-interactive SSH sessions.
+export PATH=$PATH:/usr/local/sbin:/usr/sbin
+
 run() {
     (cd "$sandbox" && "$@") || exit 1
 }

--- a/rally_ovs/plugins/ovs/deployment/engines/ovs/prepare.sh
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovs/prepare.sh
@@ -2,6 +2,9 @@
 
 set -e # exit on first error
 
+# Adjust PATH for non-interactive SSH sessions.
+export PATH=$PATH:/usr/local/sbin:/usr/sbin
+
 OVS_USER=$1
 
 echo "Prepare user $OVS_USER for ovs deployment"


### PR DESCRIPTION
Because we're not allocating a pseduo-tty when running scripts remotely,
the `PATH` is set only to `/usr/local/bin:/usr/bin`, as if we we ran:
```
$ ssh -T rally@<node> /home/rally/ovs-install.sh
```
Due to that the scripts cannot find the installed OVS/OVN daemons or
tools like `ip`.