### PR TITLE
Add the capability to remove an address from a given address_set

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -208,6 +208,11 @@ class DdCtlMixin(object):
         args += set_colval_args(*col_values)
         self.run("add", args=args)
 
+    def remove(self, table, record, *col_values):
+        args = [table, record]
+        args += set_colval_args(*col_values)
+        self.run("remove", args=args)
+
     def set(self, table, record, *col_values):
         args = [table, record]
         args += set_colval_args(*col_values)

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -373,6 +373,17 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         ovn_nbctl.add("Address_Set", name, ('addresses', ' ', addr_list))
         ovn_nbctl.flush()
 
+    def _address_set_remove_addrs(self, set_name, address_list):
+        LOG.info("remove [%s] from address_set %s" % (address_list, set_name))
+
+        name = "\"" + set_name + "\""
+        addr_list="\"" + address_list + "\""
+
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.remove("Address_Set", name, ('addresses', ' ', addr_list))
+        ovn_nbctl.flush()
+
     def _remove_address_set(self, set_name):
         LOG.info("remove %s address_set" % set_name)
 


### PR DESCRIPTION
Introduce _address_set_remove_addrs and remove routines in OvnScenario
and DdCtlMixin classes respectively in order to add the capability to
remove an address from a given address_set