### PR TITLE
Add _delete_single_acl routine in OvnScenario class

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -186,8 +186,15 @@ class OvnNbctl(OvsClient):
             self.run("acl-list", args=params)
 
 
-        def acl_del(self, lswitch):
+        def acl_del(self, lswitch, direction=None,
+                    priority=None, match=None):
             params = [lswitch]
+            if direction:
+                params.append(direction)
+            if priority:
+                params.append(priority)
+            if match:
+                params.append(match)
             self.run("acl-del", args=params)
 
         def show(self, lswitch=None):

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -190,18 +190,22 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             ovn_nbctl.acl_list(lswitch["name"])
 
 
-    @atomic.action_timer("ovn.delete_acl")
-    def _delete_acl(self, lswitches):
-        LOG.info("delete ACLs")
-
+    @atomic.action_timer("ovn.delete_all_acls")
+    def _delete_all_acls_in_lswitches(self, lswitches):
         ovn_nbctl = self.controller_client("ovn-nbctl")
-        ovn_nbctl.set_sandbox("controller-sandbox")
         ovn_nbctl.enable_batch_mode(True)
         for lswitch in lswitches:
-            LOG.info("delete ACLs on lswitch %s" % lswitch["name"])
-            ovn_nbctl.acl_del(lswitch["name"])
-
+            self._delete_acls(lswitch)
         ovn_nbctl.flush()
+
+    def _delete_acls(self, lswitch, direction=None, priority=None,
+                     match=None, flush=False):
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox")
+        LOG.info("delete ACLs on lswitch %s" % lswitch["name"])
+        ovn_nbctl.acl_del(lswitch["name"], direction, priority, match)
+        if flush:
+            ovn_nbctl.flush()
 
 
     @atomic.action_timer("ovn_network.create_routers")

--- a/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
@@ -123,7 +123,7 @@ class OvnNorthbound(ovn.OvnScenario):
 
         lswitches = self.context["ovn-nb"]
 
-        self._delete_acl(lswitches)
+        self._delete_all_acls_in_lswitches(lswitches)
 
 
     @validation.number("lports_per_lswitch", minval=1, integer_only=True)
@@ -145,7 +145,7 @@ class OvnNorthbound(ovn.OvnScenario):
                              acl_create_args, acls_per_port)
 
 
-        self._delete_acl(lswitches)
+        self._delete_all_acls_in_lswitches(lswitches)
 
     @scenario.configure(context={})
     def create_and_remove_address_set(self, name, address_list):


### PR DESCRIPTION
Introduce _delete_single_acl routine in order to add the capability to
remove just a single rule in a given ACL table. If _delete_single_acl is
run with default parameters it will erase all the ACL table for a given
switch