### PR TITLE
Use optional_action_timer instead of action_timer in _create_acl routine

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -140,7 +140,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
 
 
 
-    @atomic.action_timer("ovn.create_acl")
+    @atomic.optional_action_timer("ovn.create_acl")
     def _create_acl(self, lswitch, lports, acl_create_args, acls_per_port):
         sw = lswitch["name"]
         LOG.info("create %d ACLs on lswitch %s" % (acls_per_port, sw))


### PR DESCRIPTION
Substitute action_timer with optional_action_timer in _create_acl
as timer routine since in some cases (e.g OpenShift scenario) where
multiple ACLs are added for a given logical port could be useful
to estimate the time needed to configure the complete set of rules
instead of considering each ACL separately. If _create_acl is run
with standard parameters the timer is executed by default