### PR TITLE
Add the capability to disable lport security in _create_lports

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -68,6 +68,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         self.RESOURCE_NAME_FORMAT = "lport_XXXXXX_XXXXXX"
 
         batch = lport_create_args.get("batch", lport_amount)
+        port_security = lport_create_args.get("port_security", True)
 
         LOG.info("Create lports method: %s" % self.install_method)
         install_method = self.install_method
@@ -102,7 +103,8 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             mac = utils.get_random_mac(base_mac)
 
             ovn_nbctl.lport_set_addresses(name, [mac, ip])
-            ovn_nbctl.lport_set_port_security(name, mac)
+            if port_security:
+                ovn_nbctl.lport_set_port_security(name, mac)
 
             lports.append(lport)
 


### PR DESCRIPTION
Introduce the capability to disable logical port security in
_create_lports since some scenarios (e.g. ovn-k8s) do not
support it. lport security is enabled by default if _create_lports
is run with standard parameters