### PR TITLE
Add support for physical deployments

### DIFF
--- a/rally_ovs/plugins/ovs/deployment/engines/ovn_sandbox_controller.py
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovn_sandbox_controller.py
@@ -108,6 +108,8 @@ class OvnSandboxControllerEngine(SandboxEngine):
 
         if install_method == "docker":
             LOG.info("Do not run ssh; deployed by ansible-docker")
+        elif install_method == "physical":
+            LOG.info("Do not run ssh; deployed on physical test bed")
         elif install_method == "sandbox":
             ovs_server.ssh.run(cmd,
                             stdout=sys.stdout, stderr=sys.stderr)
@@ -129,15 +131,18 @@ class OvnSandboxControllerEngine(SandboxEngine):
 
     def cleanup(self):
         """Cleanup OVN deployment."""
+        install_method = self.config.get("install_method", "sandbox")
+
         for resource in self.deployment.get_resources():
             if resource["type"] == ResourceType.CREDENTIAL:
                 server = provider.Server.from_credentials(resource.info)
 
                 cmd = "[ -x ovs-sandbox.sh ] && ./ovs-sandbox.sh --cleanup-all"
 
-                server.ssh.run(cmd,
-                            stdout=sys.stdout, stderr=sys.stderr,
-                            raise_on_error=False)
+                if install_method == "sandbox":
+                    server.ssh.run(cmd,
+                                stdout=sys.stdout, stderr=sys.stderr,
+                                raise_on_error=False)
 
             self.deployment.delete_resource(resource.id)
 

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -62,6 +62,8 @@ class OvnNbctl(OvsClient):
                     self.cmds.append(". %s/sandbox.rc" % self.sandbox)
                 elif self.install_method == "docker":
                     cmd_prefix = ["sudo docker exec ovn-north-database"]
+                elif self.install_method == "physical":
+                    cmd_prefix = ["sudo"]
 
                 cmd = itertools.chain(cmd_prefix, ["ovn-nbctl"], opts, [cmd], args)
                 self.cmds.append(" ".join(cmd))
@@ -83,6 +85,8 @@ class OvnNbctl(OvsClient):
                     run_cmds.append("ovn-nbctl" + " ".join(self.cmds))
                 elif self.install_method == "docker":
                     run_cmds.append("sudo docker exec ovn-north-database ovn-nbctl " + " ".join(self.cmds))
+                elif self.install_method == "physical":
+                    run_cmds.append("sudo ovn-nbctl" + " ".join(self.cmds))
 
             self.ssh.run("\n".join(run_cmds),
                          stdout=sys.stdout, stderr=sys.stderr)

--- a/rally_ovs/plugins/ovs/scenarios/sandbox.py
+++ b/rally_ovs/plugins/ovs/scenarios/sandbox.py
@@ -169,6 +169,8 @@ class SandboxScenario(scenario.OvsScenario):
 
             if install_method == "docker":
                 print "Do not run ssh; sandbox installed by ansible-docker"
+            elif install_method == "physical":
+                print "Do not run ssh; sandbox installed on physical test bed"
             elif install_method == "sandbox":
                 self._do_create_sandbox(ssh, cmds)
             else:

--- a/samples/deployments/ovn-multihost-physical.json
+++ b/samples/deployments/ovn-multihost-physical.json
@@ -1,0 +1,35 @@
+{
+    "type": "OvnMultihostEngine",
+    "controller": {
+        "type": "OvnSandboxControllerEngine",
+        "deployment_name": "ovn-controller-node",
+        "install_method": "physical",
+        "controller_cidr": "192.168.42.254/24",
+        "ovs_user": "root",
+        "provider": {
+            "type": "OvsSandboxProvider",
+            "credentials": [
+                {
+                    "host": "192.168.42.254",
+                    "user": "root"}
+            ]
+        }
+    },
+    "nodes": [
+        {
+            "type": "OvnSandboxFarmEngine",
+            "deployment_name": "ovn-farm-node-0",
+            "install_method": "physical",
+            "ovs_user": "root",
+            "provider": {
+                "type": "OvsSandboxProvider",
+                "credentials": [
+                    {
+                        "host": "192.168.20.20",
+                        "user": "root"}
+                ]
+            }
+        }
+    ]
+
+}


### PR DESCRIPTION
The physical machines must have already been provisioned and must have
OVS/OVN running. To register such a deployment the new
install_method="physical" option must be used in the deployment
json/yaml files.

A sample deployment config for already provisioned physical setups can be
found at `samples/deployments/ovn-multihost-physical.json`.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>