### PR TITLE
Add OVN IGMP scale test scenario

### DIFF
--- a/rally_ovs/plugins/ovs/context/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/context/ovn_nb.py
@@ -44,6 +44,7 @@ class OvnNorthboundContext(ovsclients.ClientsMixin, context.Context):
         lswitches = ovn_nbctl.show()
 
         self.context["ovn-nb"] = lswitches
+        self.context["ovs-internal-ports"] = {}
 
     @logging.log_task_wrapper(LOG.info, _("Exit context: `ovn_nb`"))
     def cleanup(self):

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -37,6 +37,10 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         if start_cidr:
             start_cidr = netaddr.IPNetwork(start_cidr)
 
+        mcast_snoop = lswitch_create_args.get("mcast_snoop", "true")
+        mcast_idle = lswitch_create_args.get("mcast_idle_timeout", 300)
+        mcast_table_size = lswitch_create_args.get("mcast_table_size", 2048)
+
         LOG.info("Create lswitches method: %s" % self.install_method)
         ovn_nbctl = self.controller_client("ovn-nbctl")
         ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
@@ -47,7 +51,13 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         for i in range(num_switches):
             name = self.generate_random_name()
 
-            lswitch = ovn_nbctl.lswitch_add(name)
+            other_cfg = {
+                'mcast_snoop': mcast_snoop,
+                'mcast_idle_timeout': mcast_idle,
+                'mcast_table_size': mcast_table_size
+            }
+
+            lswitch = ovn_nbctl.lswitch_add(name, other_cfg)
             if start_cidr:
                 lswitch["cidr"] = start_cidr.next(i)
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2019 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import netaddr
+from rally.common import logging
+from rally_ovs.plugins.ovs.scenarios import ovn
+from rally_ovs.plugins.ovs.scenarios import ovn_network
+from rally.task import scenario
+from rally.task import validation
+from rally.task import atomic
+
+import time
+
+LOG = logging.getLogger(__name__)
+
+class OvnIGMP(ovn_network.OvnNetwork):
+    """scenarios for OVN IGMP"""
+
+    def __init__(self, context=None):
+        super(OvnIGMP, self).__init__(context)
+
+    def _lport_idx_inc(self, idx, max, inc=1):
+        idx += inc
+        return idx % max
+
+    @atomic.action_timer("ovn_igmp.run_mcast")
+    def _run_mcast(self, expected_count, lswitches, error=10):
+
+        for iteration in range(0, 60):
+            LOG.info('Iteration {}'.format(iteration))
+            ovn_sbctl = self.controller_client("ovn-sbctl")
+            igmp_flow_count = 0
+            for lswitch in lswitches:
+                igmp_flow_count += ovn_sbctl.count_igmp_flows(lswitch['name'])
+
+            LOG.info('IGMP flows: {} Expected {}'.format(
+                igmp_flow_count, expected_count))
+
+            if igmp_flow_count >= expected_count - error:
+                break;
+
+            time.sleep(0.5)
+
+    def _install_mcast_tester(self, sandboxes, path):
+        for sandbox in sandboxes:
+            ovs_ssh = self._get_conn(sandbox["name"])
+            ovs_ssh.ssh.put_file(path, '/tmp/test.c')
+
+        self._flush_conns(cmds=[
+            'gcc -lpthread -o /tmp/test /tmp/test.c'
+        ])
+
+    def _build_config_testers(self, lswitches, ports, lports_per_lswitch,
+                              mc_groups_per_network,
+                              test_dest_count,
+                              test_mcast_batch):
+        def _init_iteration():
+            return {
+                lport['name']: {'n_groups': 0, 'groups': []}
+                for lport in ports
+            }
+
+        iterations = []
+        current_iteration = _init_iteration()
+        current_total = 0
+
+        for lswitch in lswitches:
+            lports = lports_per_lswitch[lswitch["name"]]
+            if len(lports) == 0:
+                continue
+
+            lport_idx = 0
+            max_idx = len(lports)
+
+            mc_groups = [netaddr.IPAddress('239.0.0.1') + gid
+                            for gid in range(0, mc_groups_per_network)]
+
+            for mc_group in mc_groups:
+                for i in range(0, test_dest_count):
+                    lport = lports[lport_idx]
+                    lport_idx = self._lport_idx_inc(lport_idx, max_idx)
+
+                    current_iteration[lport['name']]['n_groups'] += 1
+                    current_iteration[lport['name']]['groups'].append(mc_group)
+                    current_total += 1
+
+                    if current_total == test_mcast_batch:
+                        iterations.append((current_total, current_iteration))
+                        current_iteration = _init_iteration()
+                        current_total = 0
+
+        if current_total != 0:
+            iterations.append((current_total, current_iteration))
+        return iterations
+
+    def _config_mcast_testers(self, ports, iterations):
+        for lport in ports:
+            port_name = lport["name"]
+            _, sandbox = self.context["ovs-internal-ports"][port_name]
+            ovs_ssh = self._get_conn(sandbox["name"])
+            ovs_ssh.run(
+                'echo {n} > /tmp/test-{p}-input'.format(
+                    n=len(iterations), p=port_name))
+
+        for expected_count, lport_map in iterations:
+            for port_name, port_groups in lport_map.iteritems():
+                _, sandbox = self.context["ovs-internal-ports"][port_name]
+                ovs_ssh = self._get_conn(sandbox["name"])
+                ovs_ssh.run(
+                    'echo {n} >> /tmp/test-{p}-input'.format(
+                        n=port_groups['n_groups'], p=port_name))
+                for mc_group in port_groups['groups']:
+                    ovs_ssh.run(
+                        'echo {g} >> /tmp/test-{p}-input'.format(
+                            g=mc_group, p=port_name))
+            self._flush_conns()
+
+    def _start_mcast_tester(self, port_name):
+        _, sandbox = self.context["ovs-internal-ports"][port_name]
+        ovs_ssh = self._get_conn(sandbox["name"])
+        input_file = '/tmp/test-{p}-input'.format(p=port_name)
+        ovs_ssh.run(
+            'ip netns exec {p} /tmp/test {ifile}'.format(
+                p=port_name, ifile=input_file))
+
+    def _trigger_mcast_tester(self, port_name):
+        _, sandbox = self.context["ovs-internal-ports"][port_name]
+        ovs_ssh = self._get_conn(sandbox["name"])
+        ovs_ssh.run(
+            "kill -s SIGUSR1 `ps aux | grep {p} | grep -v grep | "
+            "awk '{{print $2}}'` &> /dev/null || /bin/true".format(
+        p=port_name))
+
+    def _start_mcast(self, lswitches, all_lports, lports_per_lswitch,
+                     mc_groups_per_network, test_dest_count, test_mcast_batch):
+
+        # Avoid lazy connection creation:
+        ovn_sbctl = self.controller_client("ovn-sbctl")
+
+        # Build configuration for each port for each iteration
+        iterations = self._build_config_testers(lswitches, all_lports,
+                                                lports_per_lswitch,
+                                                mc_groups_per_network,
+                                                test_dest_count,
+                                                test_mcast_batch)
+
+        # Write the config on the DUTs (for each port).
+        self._config_mcast_testers(all_lports, iterations)
+
+        # Start the tester apps (one for each port).
+        for lport in all_lports:
+            port_name = lport["name"]
+            self._start_mcast_tester(port_name)
+        self._flush_conns()
+
+        LOG.info('Finished configuring multicast receivers')
+
+        time.sleep(10)
+
+        # Run the test iterations. Every iteration is triggered by sending
+        # SIGUSR1 to the test apps.
+        total_expected = 0
+        for iteration, (expected_count, port_map) in enumerate(iterations):
+            for port_name in port_map.iterkeys():
+                self._trigger_mcast_tester(port_name)
+
+            self._flush_conns()
+            total_expected += expected_count
+
+            LOG.info(
+                'Started {} multicast receivers. Total until now: {}'.format(
+            expected_count, total_expected))
+            self._run_mcast(total_expected, lswitches)
+
+    def _cleanup_mcast_tests(self):
+        self._flush_conns(cmds=[
+            'killall -s KILL test &> /dev/null || /bin/true',
+            'rm -rf /tmp/test*input'
+        ])
+
+    def _cleanup_mcast(self, lswitches, sandboxes):
+        LOG.info('Cleaning up setup...')
+
+        self._delete_lswitch(lswitches)
+        self._cleanup_ovs_internal_ports(sandboxes)
+
+    @validation.number("ports_per_network", minval=4, integer_only=True)
+    @scenario.configure(context={})
+    def igmp_scale(self, network_create_args=None,
+                   port_create_args=None,
+                   ports_per_network=None,
+                   port_bind_args=None,
+                   cleanup=True,
+                   igmp_args=None):
+        sandboxes = self.context["sandboxes"]
+
+        lswitches = self._create_networks(network_create_args)
+
+        lports = []
+        lports_per_lswitch = {}
+
+        mc_groups_per_network = igmp_args.get("group_count", 1)
+        test_dest_count = igmp_args.get("receivers", 2)
+        test_pkt_size = igmp_args.get("pkt_size", 64)
+        test_bw = igmp_args.get("bw", "1K")
+        test_mcast_batch = igmp_args.get("mcast_batch", 200)
+        test_mcast_rcv_path = igmp_args.get("mcast_recv_path");
+
+        if cleanup:
+            self._cleanup_mcast_tests()
+
+        for lswitch in lswitches:
+            switch_lports = self._create_lports(lswitch, port_create_args,
+                                                ports_per_network)
+            lports_per_lswitch[lswitch["name"]] = switch_lports
+            lports += switch_lports
+
+        self._bind_ports_and_wait(lports, sandboxes, port_bind_args)
+
+        LOG.info('Sleeping for a bit before starting multicast..')
+        time.sleep(10)
+
+        self._install_mcast_tester(sandboxes, test_mcast_rcv_path)
+
+        self._start_mcast(lswitches, lports, lports_per_lswitch,
+                          mc_groups_per_network, test_dest_count,
+                          test_mcast_batch)
+
+        if cleanup:
+            LOG.info('Sleeping for a bit before cleaning up..')
+            time.sleep(20)
+            self._cleanup_mcast(lswitches, sandboxes)

--- a/samples/deployments/ovn-multihost-single-controller-physical.json
+++ b/samples/deployments/ovn-multihost-single-controller-physical.json
@@ -1,0 +1,36 @@
+{
+    "controller": {
+        "controller_cidr": "10.19.188.190/23",
+        "deployment_name": "ovn-controller-node",
+        "install_method": "physical",
+        "ovs_user": "root",
+        "provider": {
+            "credentials": [
+                {
+                    "host": "10.19.188.190",
+                    "user": "root"
+                }
+            ],
+            "type": "OvsSandboxProvider"
+        },
+        "type": "OvnSandboxControllerEngine"
+    },
+    "nodes": [
+        {
+            "deployment_name": "ovn-farm-node-0",
+            "install_method": "physical",
+            "ovs_user": "root",
+            "provider": {
+                "credentials": [
+                    {
+                        "host": "10.19.188.190",
+                        "user": "root"
+                    }
+                ],
+                "type": "OvsSandboxProvider"
+            },
+            "type": "OvnSandboxFarmEngine"
+        }
+    ],
+    "type": "OvnMultihostEngine"
+}

--- a/samples/tasks/scenarios/ovn-network/create_and_bind_internal_ports.json
+++ b/samples/tasks/scenarios/ovn-network/create_and_bind_internal_ports.json
@@ -1,0 +1,67 @@
+{% set farm_nodes = farm_nodes or 1 %}
+{% set networks = networks or 1 %}
+{% set internal_ports_cleanup = internal_ports_cleanup or 0 %}
+{
+    "version": 2,
+    "title": "Create and bind port",
+    "subtasks": [
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Create sandbox on farm {{i}}",
+            "workloads": [{
+                "name": "OvnSandbox.create_sandbox",
+                "args": {
+                    "sandbox_create_args": {
+                        "farm": "ovn-farm-node-{{i}}",
+                        "amount": 1,
+                        "batch" : 1,
+                        "start_cidr": "192.168.42.{{i + 10}}/24",
+                        "net_dev": "eth1",
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": 1},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {% endfor %}
+        {% for i in range(0, networks) %}
+        {
+            "title": "Create and bind internal ports",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnNetwork.create_and_bind_ports",
+                    "args": {
+                        "network_create_args": {
+                            "amount": 1,
+                            "batch": 1,
+                            "start_cidr": "42.{{i}}.1.0/24"
+                        },
+                        "port_create_args" : {"batch": 2},
+                        "ports_per_network": {{ports_per_network}},
+                        "port_bind_args": {
+                            "internal": true,
+                            "wait_up": true
+                        },
+                        "internal_ports_cleanup": {{internal_ports_cleanup}}
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": {"tag": "ToR1"},
+                        "ovn_nb": {}
+                    }
+                }
+            ]
+        },
+        {% endfor %}
+    ]
+}

--- a/samples/tasks/scenarios/ovn-network/igmp_scale.json
+++ b/samples/tasks/scenarios/ovn-network/igmp_scale.json
@@ -1,0 +1,79 @@
+{% set farm_nodes = farm_nodes or 1 %}
+{% set networks = networks or 1 %}
+{% set networks_concurrent = networks_concurrent or 1 %}
+{% set cleanup = cleanup or 0 %}
+{% set igmp_group_count = igmp_group_count or 1 %}
+{% set igmp_receiver_count = igmp_receiver_count or 1 %}
+{% set igmp_mcast_batch = igmp_mcast_batch or 200 %}
+{
+    "version": 2,
+    "title": "IGMP scale test",
+    "subtasks": [
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Create sandbox on farm {{i}}",
+            "workloads": [{
+                "name": "OvnSandbox.create_sandbox",
+                "args": {
+                    "sandbox_create_args": {
+                        "farm": "ovn-farm-node-{{i}}",
+                        "amount": 1,
+                        "batch" : 1,
+                        "start_cidr": "10.19.188.190/24",
+                        "net_dev": "eth1",
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": 1},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {% endfor %}
+        {
+            "title": "IGMP Scale Test",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnIGMP.igmp_scale",
+                    "args": {
+                        "network_create_args": {
+                            "amount": 1,
+                            "batch": 1,
+                            "start_cidr": "42.1.1.0/24",
+                            "mcast_snoop": "true",
+                            "mcast_idle_timeout": 3600,
+                            "mcast_table_size": 1000000
+                        },
+                        "port_create_args" : {"batch": 2},
+                        "ports_per_network": {{ports_per_network}},
+                        "port_bind_args": {
+                            "internal": true,
+                            "wait_up": true
+                        },
+                        "cleanup": {{cleanup}},
+                        "igmp_args": {
+                            "group_count": {{igmp_group_count}},
+                            "receivers": {{igmp_receiver_count}},
+                            "mcast_batch": {{igmp_mcast_batch}},
+                            "mcast_recv_path": {{igmp_mcast_recv_path}}
+                        }
+                    },
+                    "runner": {
+                        "type": "constant",
+                        "concurrency": {{networks_concurrent}},
+                        "times": {{networks}}
+                    },
+                    "context": {
+                        "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": {"tag": "ToR1"},
+                        "ovn_nb": {}
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/samples/tasks/scenarios/ovn-network/mcast-tester.c
+++ b/samples/tasks/scenarios/ovn-network/mcast-tester.c
@@ -1,0 +1,115 @@
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <semaphore.h>
+#include <assert.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+
+sem_t sem;
+
+void signal_handler(int signo)
+{
+    sem_post(&sem);
+}
+
+#define MAX_SLEEP_PER_GROUP_US 200000
+#define MAX_GROUPS 10000
+#define MAX_GROUP_NAME 256
+
+struct iteration {
+    uint32_t n_groups;
+    char groups[MAX_GROUPS][MAX_GROUP_NAME];
+    int sd[MAX_GROUPS];
+};
+
+static void init_socket(int *sd)
+{
+    struct sockaddr_in addr;
+
+    *sd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (*sd < 0) {
+        perror("opening datagram socket");
+        exit(1);
+    }
+
+    int reuse=1;
+
+    if (setsockopt(*sd, SOL_SOCKET, SO_REUSEADDR,
+                   (char *)&reuse, sizeof(reuse)) < 0) {
+        perror("setting SO_REUSEADDR");
+        exit(1);
+    }
+
+    memset((char *) &addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(5555);;
+    addr.sin_addr.s_addr  = INADDR_ANY;
+
+    if (bind(*sd, (struct sockaddr*)&addr, sizeof(addr))) {
+        perror("binding datagram socket");
+        exit(1);
+    }
+}
+
+static void join_mcast_group(int sd, const char *g_name)
+{
+    struct ip_mreq group;
+
+    usleep(rand() % (MAX_SLEEP_PER_GROUP_US / MAX_GROUPS));
+
+    group.imr_multiaddr.s_addr = inet_addr(g_name);
+    if (setsockopt(sd, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                   (char *)&group, sizeof(group)) < 0) {
+        perror("adding multicast group");
+        exit(1);
+    }
+}
+
+int main (int argc, char *argv[])
+{
+    struct iteration *iterations;
+    uint32_t i;
+    uint32_t j;
+
+    sem_init(&sem, 0, 0);
+
+    signal(SIGUSR1, signal_handler);
+
+    FILE *f;
+
+    assert(f = fopen(argv[1], "r"));
+
+    uint32_t n_iterations;
+
+    assert(fscanf(f, "%u\n", &n_iterations) == 1);
+    iterations = malloc(n_iterations * sizeof(*iterations));
+    assert(iterations);
+
+    for (i = 0; i < n_iterations; i++) {
+        assert(fscanf(f, "%u\n", &iterations[i].n_groups));
+
+        for (j = 0; j < iterations[i].n_groups; j++) {
+            assert(fgets(iterations[i].groups[j], MAX_GROUP_NAME, f));
+            init_socket(&iterations[i].sd[j]);
+        }
+    }
+
+    daemon(1, 0);
+
+    for (i = 0; i < n_iterations; i++) {
+        sem_wait(&sem);
+
+        for (j = 0; j < iterations[i].n_groups; j++) {
+            join_mcast_group(iterations[i].sd[j], iterations[i].groups[j]);
+        }
+    }
+
+    for (;;) sleep(1000000);
+    return 0;
+}


### PR DESCRIPTION
To emulate multicast receivers, a small C app is used (mcast-tester.c).

Also add support for OVS internal ports. Each OVS internal port gets
bound to a "fake VM" (network namespace).

Signed-off-by: Dumitru Ceara <dceara@redhat.com>