### PR TITLE
Add support for physical deployments with OVN running in docker containers.

### DIFF
--- a/rally_ovs/plugins/ovs/context/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/context/ovn_nb.py
@@ -40,7 +40,8 @@ class OvnNorthboundContext(ovsclients.ClientsMixin, context.Context):
         super(OvnNorthboundContext, self).setup()
 
         ovn_nbctl = self.controller_client("ovn-nbctl")
-        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
         lswitches = ovn_nbctl.show()
 
         self.context["ovn-nb"] = lswitches

--- a/rally_ovs/plugins/ovs/context/sandbox.py
+++ b/rally_ovs/plugins/ovs/context/sandbox.py
@@ -70,7 +70,8 @@ class Sandbox(context.Context):
 
             for k,v in six.iteritems(info["sandboxes"]):
                 if tag == "all" or v == tag:
-                    sandbox = {"name": k, "tag": v, "farm": info["farm"]}
+                    sandbox = {"name": k, "tag": v, "farm": info["farm"],
+                               "host_container": info["host_container"]}
                     sandboxes.append(sandbox)
 
         self.context["sandboxes"] = sandboxes

--- a/rally_ovs/plugins/ovs/deployment/engines/ovn_sandbox_controller.py
+++ b/rally_ovs/plugins/ovs/deployment/engines/ovn_sandbox_controller.py
@@ -63,6 +63,7 @@ class OvnSandboxControllerEngine(SandboxEngine):
         "properties": {
             "type": {"type": "string"},
             "install_method": {"type": "string"},
+            "host_container": {"type": "string"},
             "deployment_name": {"type": "string"},
             "http_proxy": {"type": "string"},
             "https_proxy": {"type": "string"},
@@ -95,6 +96,8 @@ class OvnSandboxControllerEngine(SandboxEngine):
         if not deployment_name:
             deployment_name = self.config.get("deployment_name", None)
 
+        host_container = self.config.get("host_container", None)
+
         ovs_user = self.config.get("ovs_user", OVS_USER)
         ovs_controller_cidr = self.config.get("controller_cidr")
         net_dev = self.config.get("net_dev", "eth0")
@@ -114,7 +117,7 @@ class OvnSandboxControllerEngine(SandboxEngine):
             ovs_server.ssh.run(cmd,
                             stdout=sys.stdout, stderr=sys.stderr)
         else:
-            print "Invalid install method for controller"
+            print("Invalid install method for controller")
             exit(1)
 
         self.deployment.add_resource(provider_name="OvnSandboxControllerEngine",
@@ -125,7 +128,8 @@ class OvnSandboxControllerEngine(SandboxEngine):
                             type=ResourceType.CONTROLLER,
                             info={
                                   "ip":ovs_controller_cidr.split('/')[0],
-                                  "deployment_name":deployment_name})
+                                  "deployment_name":deployment_name,
+                                  "host_container":host_container})
 
         return {"admin": None}
 

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -43,7 +43,8 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
 
         LOG.info("Create lswitches method: %s" % self.install_method)
         ovn_nbctl = self.controller_client("ovn-nbctl")
-        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
         ovn_nbctl.enable_batch_mode()
 
         flush_count = batch
@@ -81,7 +82,8 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         batch = router_create_args.get("batch", 1)
 
         ovn_nbctl = self.controller_client("ovn-nbctl")
-        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method)
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
         ovn_nbctl.enable_batch_mode()
 
         flush_count = batch
@@ -106,8 +108,8 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         LOG.info("Connect network %s to router %s" % (network["name"], router["name"]))
 
         ovn_nbctl = self.controller_client("ovn-nbctl")
-        install_method = self.install_method
-        ovn_nbctl.set_sandbox("controller-sandbox", install_method)
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
         ovn_nbctl.enable_batch_mode(False)
 
 

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -25,7 +25,7 @@ class SshClient(OvsClient):
 
 
     def create_client(self):
-        print "*********   call OvnNbctl.create_client"
+        print("*********   call OvnNbctl.create_client")
         return get_ssh_from_credential(self.credential)
 
 
@@ -44,9 +44,11 @@ class OvnNbctl(OvsClient):
         def enable_batch_mode(self, value=True):
             self.batch_mode = bool(value)
 
-        def set_sandbox(self, sandbox, install_method="sandbox"):
+        def set_sandbox(self, sandbox, install_method="sandbox",
+                        host_container=None):
             self.sandbox = sandbox
             self.install_method = install_method
+            self.host_container = host_container
 
         def run(self, cmd, opts=[], args=[], stdout=sys.stdout, stderr=sys.stderr):
             self.cmds = self.cmds or []
@@ -63,7 +65,10 @@ class OvnNbctl(OvsClient):
                 elif self.install_method == "docker":
                     cmd_prefix = ["sudo docker exec ovn-north-database"]
                 elif self.install_method == "physical":
-                    cmd_prefix = ["sudo"]
+                    if self.host_container:
+                        cmd_prefix = ["sudo docker exec " + self.host_container]
+                    else:
+                        cmd_prefix = ["sudo"]
 
                 cmd = itertools.chain(cmd_prefix, ["ovn-nbctl"], opts, [cmd], args)
                 self.cmds.append(" ".join(cmd))
@@ -86,7 +91,12 @@ class OvnNbctl(OvsClient):
                 elif self.install_method == "docker":
                     run_cmds.append("sudo docker exec ovn-north-database ovn-nbctl " + " ".join(self.cmds))
                 elif self.install_method == "physical":
-                    run_cmds.append("sudo ovn-nbctl" + " ".join(self.cmds))
+                    if self.host_container:
+                        cmd_prefix = "sudo docker exec " + self.host_container + " ovn-nbctl"
+                    else:
+                        cmd_prefix = "sudo ovn-nbctl"
+
+                    run_cmds.append(cmd_prefix + " ".join(self.cmds))
 
             self.ssh.run("\n".join(run_cmds),
                          stdout=sys.stdout, stderr=sys.stderr)
@@ -118,7 +128,7 @@ class OvnNbctl(OvsClient):
 
             self.run("ls-add", args=params)
 
-            for cfg, val in other_cfg.iteritems():
+            for cfg, val in other_cfg.items():
                 param_cfg = 'other_config:{c}="{v}"'.format(c=cfg, v=val)
                 params = ['Logical_Switch', name, param_cfg]
                 self.run("set", args=params)
@@ -226,7 +236,7 @@ class OvnNbctl(OvsClient):
             self.batch_mode = batch_mode
 
     def create_client(self):
-        print "*********   call OvnNbctl.create_client"
+        print("*********   call OvnNbctl.create_client")
 
         client = self._OvnNbctl(self.credential)
 
@@ -246,9 +256,11 @@ class OvnSbctl(OvsClient):
         def enable_batch_mode(self, value=True):
             self.batch_mode = bool(value)
 
-        def set_sandbox(self, sandbox, install_method="sandbox"):
+        def set_sandbox(self, sandbox, install_method="sandbox",
+                        host_container=None):
             self.sandbox = sandbox
             self.install_method = install_method
+            self.host_container = host_container
 
         def run(self, cmd, opts=[], args=[], stdout=sys.stdout, stderr=sys.stderr):
             self.cmds = self.cmds or []
@@ -265,7 +277,10 @@ class OvnSbctl(OvsClient):
                 elif self.install_method == "docker":
                     cmd_prefix = ["sudo docker exec ovn-north-database"]
                 elif self.install_method == "physical":
-                    cmd_prefix = ["sudo"]
+                    if self.host_container:
+                        cmd_prefix = ["sudo docker exec " + self.host_container]
+                    else:
+                        cmd_prefix = ["sudo"]
 
                 cmd = itertools.chain(cmd_prefix, ["ovn-sbctl"], opts, [cmd], args)
                 self.cmds.append(" ".join(cmd))
@@ -288,7 +303,10 @@ class OvnSbctl(OvsClient):
                 elif self.install_method == "docker":
                     run_cmds.append("sudo docker exec ovn-north-database ovn-sbctl " + " ".join(self.cmds))
                 elif self.install_method == "physical":
-                    run_cmds.append("sudo ovn-sbctl" + " ".join(self.cmds))
+                    if self.host_container:
+                        run_cmds.append("sudo docker exec " + self.host_container + " ovn-sbctl" + " ".join(self.cmds))
+                    else:
+                        run_cmds.append("sudo ovn-sbctl" + " ".join(self.cmds))
 
             self.ssh.run("\n".join(run_cmds),
                          stdout=sys.stdout, stderr=sys.stderr)
@@ -329,7 +347,7 @@ class OvnSbctl(OvsClient):
             self.batch_mode = batch_mode
 
     def create_client(self):
-        print "*********   call OvnSbctl.create_client"
+        print("*********   call OvnSbctl.create_client")
 
         client = self._OvnSbctl(self.credential)
 
@@ -347,10 +365,20 @@ class OvsSsh(OvsClient):
         def enable_batch_mode(self, value=True):
             self.batch_mode = bool(value)
 
+        def set_sandbox(self, sandbox, install_method="sandbox",
+                        host_container=None):
+            self.sandbox = sandbox
+            self.install_method = install_method
+            self.host_container = host_container
+
         def run(self, cmd):
             self.cmds = self.cmds or []
 
-            self.cmds.append(cmd)
+            if self.host_container:
+                self.cmds.append('sudo docker exec ' + self.host_container + ' ' + cmd)
+            else:
+                self.cmds.append(cmd)
+
             if self.batch_mode:
                 return
 
@@ -369,7 +397,7 @@ class OvsSsh(OvsClient):
             self.cmds = None
 
     def create_client(self):
-        print "*********   call OvsSsh.create_client"
+        print("*********   call OvsSsh.create_client")
         client = self._OvsSsh(self.credential)
         return client
 
@@ -389,9 +417,11 @@ class OvsVsctl(OvsClient):
         def enable_batch_mode(self, value=True):
             self.batch_mode = bool(value)
 
-        def set_sandbox(self, sandbox, install_method="sandbox"):
+        def set_sandbox(self, sandbox, install_method="sandbox",
+                        host_container=None):
             self.sandbox = sandbox
             self.install_method = install_method
+            self.host_container = host_container
 
         def run(self, cmd, opts=[], args=[], extras=[]):
             self.cmds = self.cmds or []
@@ -410,7 +440,11 @@ class OvsVsctl(OvsClient):
                                      " " + " ".join(extras))
 
             if self.install_method != "docker":
-                cmd = itertools.chain(["ovs-vsctl"], opts, [cmd], args, extras)
+                if self.host_container:
+                    cmd_prefix = ["sudo docker exec " + self.host_container + " ovs-vsctl"]
+                else:
+                    cmd_prefix = ["ovs-vsctl"]
+                cmd = itertools.chain(cmd_prefix, opts, [cmd], args, extras)
                 self.cmds.append(" ".join(cmd))
 
             if self.batch_mode:
@@ -437,7 +471,7 @@ class OvsVsctl(OvsClient):
 
         def add_port(self, bridge, port, may_exist=True, internal=False):
             opts = ['--may-exist'] if may_exist else None
-            extras = ['--', 'set interface {} type=internal'.format(port)] if internal else None
+            extras = ['--', 'set interface {} type=internal'.format(port)] if internal else []
             self.run('add-port', opts, [bridge, port], extras)
 
         def del_port(self, port):
@@ -449,7 +483,7 @@ class OvsVsctl(OvsClient):
             self.run("set", args=args)
 
     def create_client(self):
-        print "*********   call OvsVsctl.create_client"
+        print("*********   call OvsVsctl.create_client")
         client = self._OvsVsctl(self.credential)
         return client
 
@@ -465,9 +499,11 @@ class OvsOfctl(OvsClient):
             self.context = {}
             self.sandbox = None
 
-        def set_sandbox(self, sandbox, install_method="sandbox"):
+        def set_sandbox(self, sandbox, install_method="sandbox",
+                        host_container=None):
             self.sandbox = sandbox
             self.install_method = install_method
+            self.host_container = host_container
 
         def run(self, cmd, opts=[], args=[], stdout=sys.stdout, stderr=sys.stderr):
             # TODO: add support for docker
@@ -477,7 +513,11 @@ class OvsOfctl(OvsClient):
                 if self.install_method == "sandbox":
                     cmds.append(". %s/sandbox.rc" % self.sandbox)
 
-            cmd = itertools.chain(["ovs-ofctl"], opts, [cmd], args)
+            if self.install_method == "physical" and self.host_container:
+                cmd_prefix = ["sudo docker exec " + self.host_container + " ovs-ofctl"]
+            else:
+                cmd_prefix = ["ovs-ofctl"]
+            cmd = itertools.chain(cmd_prefix, opts, [cmd], args)
             cmds.append(" ".join(cmd))
             self.ssh.run("\n".join(cmds),
                          stdout=stdout, stderr=stderr)
@@ -491,6 +531,6 @@ class OvsOfctl(OvsClient):
             return len(oflow_data)
 
     def create_client(self):
-        print "*********   call OvsOfctl.create_client"
+        print("*********   call OvsOfctl.create_client")
         client = self._OvsOfctl(self.credential)
         return client

--- a/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
@@ -114,7 +114,7 @@ class OvnIGMP(ovn_network.OvnNetwork):
                     n=len(iterations), p=port_name))
 
         for expected_count, lport_map in iterations:
-            for port_name, port_groups in lport_map.iteritems():
+            for port_name, port_groups in lport_map.items():
                 _, sandbox = self.context["ovs-internal-ports"][port_name]
                 ovs_ssh = self._get_conn(sandbox["name"])
                 ovs_ssh.run(
@@ -204,6 +204,9 @@ class OvnIGMP(ovn_network.OvnNetwork):
                    cleanup=True,
                    igmp_args=None):
         sandboxes = self.context["sandboxes"]
+        if not sandboxes:
+            # when there is no sandbox specified, bind on all sandboxes.
+            sandboxes = utils.get_sandboxes(self.task["deployment_uuid"])
 
         lswitches = self._create_networks(network_create_args)
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
@@ -60,7 +60,7 @@ class OvnNorthbound(ovn.OvnScenario):
         for lswitch in lswitches:
             self._create_lports(lswitch, lport_create_args, lports_per_lswitch)
 
-        self._list_lports(lswitches, self.install_method)
+        self._list_lports(lswitches)
 
 
     @scenario.configure(context={})

--- a/rally_ovs/plugins/ovs/scenarios/ovn_network.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_network.py
@@ -91,6 +91,9 @@ class OvnNetwork(ovn.OvnScenario):
                               internal_ports_cleanup=True):
 
         sandboxes = self.context["sandboxes"]
+        if not sandboxes:
+            # when there is no sandbox specified, bind on all sandboxes.
+            sandboxes = utils.get_sandboxes(self.task["deployment_uuid"])
 
         use_existing_networks = port_create_args. \
             get("use_existing_networks", False)

--- a/rally_ovs/plugins/ovs/scenarios/ovn_sandbox.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_sandbox.py
@@ -48,6 +48,7 @@ class OvnSandbox(sandbox.SandboxScenario):
         controller_cidr = config["controller"].get("controller_cidr", None)
         net_dev = config["controller"].get("net_dev", None)
         deployment_name = config["controller"].get("deployment_name")
+        host_container = config["controller"].get("host_container")
 
         controller_cidr = controller_create_args.get("controller_cidr",
                                                             controller_cidr)
@@ -59,7 +60,8 @@ class OvnSandbox(sandbox.SandboxScenario):
         if net_dev == None:
             raise NoSuchConfigField(name="net_dev")
 
-        self._create_controller(deployment_name, controller_cidr, net_dev)
+        self._create_controller(deployment_name, host_container,
+                                controller_cidr, net_dev)
 
 
 

--- a/rally_ovs/plugins/ovs/utils.py
+++ b/rally_ovs/plugins/ovs/utils.py
@@ -139,7 +139,8 @@ def get_sandboxes(deploy_uuid, farm="", tag=""):
             if tag and tag != v:
                 continue
 
-            sandbox = {"name": k, "tag": v, "farm": info["farm"]}
+            sandbox = {"name": k, "tag": v, "farm": info["farm"],
+                       "host_container": info["host_container"]}
             sandboxes.append(sandbox)
 
 

--- a/samples/deployments/ovn-multihost-physical-docker.json
+++ b/samples/deployments/ovn-multihost-physical-docker.json
@@ -1,0 +1,70 @@
+{
+    "controller": {
+        "controller_cidr": "10.19.188.192/23",
+        "deployment_name": "ovn-controller-node",
+        "install_method": "physical",
+        "host_container": "ovn-central",
+        "ovs_user": "root",
+        "provider": {
+            "credentials": [
+                {
+                    "host": "10.19.188.192",
+                    "user": "root"
+                }
+            ],
+            "type": "OvsSandboxProvider"
+        },
+        "type": "OvnSandboxControllerEngine"
+    },
+    "nodes": [
+        {
+            "deployment_name": "ovn-farm-node-0",
+            "install_method": "physical",
+            "host_container": "ovn-gw-1",
+            "ovs_user": "root",
+            "provider": {
+                "credentials": [
+                    {
+                        "host": "10.19.188.192",
+                        "user": "root"
+                    }
+                ],
+                "type": "OvsSandboxProvider"
+            },
+            "type": "OvnSandboxFarmEngine"
+        },
+        {
+            "deployment_name": "ovn-farm-node-1",
+            "install_method": "physical",
+            "host_container": "ovn-chassis-1",
+            "ovs_user": "root",
+            "provider": {
+                "credentials": [
+                    {
+                        "host": "10.19.188.192",
+                        "user": "root"
+                    }
+                ],
+                "type": "OvsSandboxProvider"
+            },
+            "type": "OvnSandboxFarmEngine"
+        },
+        {
+            "deployment_name": "ovn-farm-node-2",
+            "install_method": "physical",
+            "host_container": "ovn-chassis-2",
+            "ovs_user": "root",
+            "provider": {
+                "credentials": [
+                    {
+                        "host": "10.19.188.192",
+                        "user": "root"
+                    }
+                ],
+                "type": "OvsSandboxProvider"
+            },
+            "type": "OvnSandboxFarmEngine"
+        }
+    ],
+    "type": "OvnMultihostEngine"
+}


### PR DESCRIPTION
This extends the "physical deployments" support from commit
c8f4387bb4b4d71b27b277a3091b17bdb75a9b7e in order to allow
ovn-scale-test to connect to docker containers running OVN (central or
controller) on physical hosts.

Also:
- change Python2 syntax to Python3-isms (e.g., print, iteritems).
- skip unnecessary SSH connections when
  creating/starting/stopping/deleting "sandboxes" when using physical
  deployments.
- fix OvsVsctl.add_port() for the case when non-internal interfaces are
  used.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>