### PR TITLE
Add support for provisioning ovn-fake-multinode deployments on demand.

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -346,6 +346,18 @@ class OvnSbctl(OvsClient):
             self.run("sync", opts)
             self.batch_mode = batch_mode
 
+        def chassis_bound(self, chassis_name):
+            batch_mode = self.batch_mode
+            if batch_mode:
+                self.flush()
+                self.batch_mode = False
+            stdout = StringIO()
+            self.run("find chassis", ["--bare", "--columns _uuid"],
+                     ["name={}".format(chassis_name)],
+                     stdout=stdout)
+            self.batch_mode = batch_mode
+            return len(stdout.getvalue().splitlines()) == 1
+
     def create_client(self):
         print("*********   call OvnSbctl.create_client")
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2020, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from rally_ovs.plugins.ovs.scenarios import ovn
+from rally.task import atomic
+from rally.task import scenario
+import time
+
+"""Scenario to dynamically add/delete ovn nodes running in containers.
+
+This scenario is applicable for clusters deployed using:
+https://github.com/ovn-org/ovn-fake-multinode
+"""
+class OvnFakeMultinode(ovn.OvnScenario):
+
+    def __init__(self, context=None):
+        super(OvnFakeMultinode, self).__init__(context)
+        self._init_sandboxes(context)
+
+    def _init_sandboxes(self, context):
+        self._sandboxes = {sb["farm"]: sb for sb in self.context["sandboxes"]}
+
+    def _get_sandbox(self, sb_name):
+        return self._sandboxes[sb_name]
+
+    def _get_sandbox_conn(self, sb_name, sb):
+        farm = sb["farm"]
+        ssh = self.farm_clients(farm, "ovs-ssh")
+        ssh.set_sandbox(sb_name, self.install_method)
+        ssh.enable_batch_mode(False)
+        return ssh
+
+    @atomic.action_timer("OvnFakeMultinode.add_central_node")
+    def _add_central(self, ssh_conn, node_net, node_net_len, node_ip,
+                     ovn_fake_path):
+        cmd = "cd {} && CHASSIS_COUNT=0 GW_COUNT=0 IP_HOST={} IP_CIDR={} IP_START={} ./ovn_cluster.sh start || true".format(
+            ovn_fake_path, node_net, node_net_len, node_ip
+        )
+        ssh_conn.run(cmd)
+
+    @atomic.action_timer("OvnFakeMultinode.add_chassis_node")
+    def _add_chassis(self, ssh_conn, node_net, node_net_len, node_ip, node_name,
+                     ovn_fake_path):
+        invalid_remote = "tcp:0.0.0.1:6642"
+        cmd = "cd {} && IP_HOST={} IP_CIDR={} IP_START={} ./ovn_cluster.sh add-chassis {} {} || true".format(
+            ovn_fake_path, node_net, node_net_len, node_ip, node_name, invalid_remote
+        )
+        ssh_conn.run(cmd)
+
+    @atomic.action_timer("OvnFakeMultinode.connect_chassis_node")
+    def _connect_chassis(self, ssh_conn, node_name, central_ip, ovn_fake_path):
+        cmd = "cd {} && ./ovn_cluster.sh set-chassis-ovn-remote {} tcp:{}:6642 || true".format(
+            ovn_fake_path, node_name, central_ip
+        )
+        ssh_conn.run(cmd)
+
+    @atomic.action_timer("ovnFakeMultinode.wait_chassis_node")
+    def _wait_chassis(self, sbctl_conn, chassis_name, max_timeout_s):
+        for i in range(0, max_timeout_s * 10):
+            if sbctl_conn.chassis_bound(chassis_name):
+                break
+            time.sleep(0.1)
+
+    @atomic.action_timer("OvnFakeMultinode.del_chassis_node")
+    def _del_chassis(self, ssh_conn, node_name, ovn_fake_path):
+        cmd = "cd {} && ./ovn_cluster.sh stop-chassis {} || true".format(
+            ovn_fake_path, node_name
+        )
+        ssh_conn.run(cmd)
+
+    @atomic.action_timer("OvnFakeMultinode.del_central_node")
+    def _del_central(self, ssh_conn, ovn_fake_path):
+        cmd = "cd {} && CHASSIS_COUNT=0 GW_COUNT=0 ./ovn_cluster.sh stop || true".format(
+            ovn_fake_path
+        )
+        ssh_conn.run(cmd)
+
+    @scenario.configure(context={})
+    def add_central_node(self, fake_multinode_args = {}):
+        ssh = self.controller_client("ovs-ssh")
+        ssh.set_sandbox("controller-sandbox", self.install_method)
+        ssh.enable_batch_mode(False)
+
+        node_net = fake_multinode_args.get("node_net")
+        node_net_len = fake_multinode_args.get("node_net_len")
+        node_ip = fake_multinode_args.get("node_ip")
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+
+        self._add_central(ssh, node_net, node_net_len, node_ip, ovn_fake_path)
+
+    @scenario.configure(context={})
+    def add_chassis_node(self, fake_multinode_args = {}):
+        farm = fake_multinode_args.get("farm")
+        sb = self._get_sandbox(farm)
+        ssh = self._get_sandbox_conn(sb["name"], sb)
+
+        node_net = fake_multinode_args.get("node_net")
+        node_net_len = fake_multinode_args.get("node_net_len")
+        node_ip = fake_multinode_args.get("node_ip")
+        node_name = sb["host_container"]
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+        self._add_chassis(ssh, node_net, node_net_len, node_ip, node_name,
+                          ovn_fake_path)
+
+    @scenario.configure(context={})
+    def connect_chassis_node(self, fake_multinode_args = {}):
+        farm = fake_multinode_args.get("farm")
+        sb = self._get_sandbox(farm)
+        ssh = self._get_sandbox_conn(sb["name"], sb)
+
+        central_ip = fake_multinode_args.get("central_ip")
+        node_name = sb["host_container"]
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+        self._connect_chassis(ssh, node_name, central_ip, ovn_fake_path)
+
+    @scenario.configure(context={})
+    def wait_chassis_node(self, fake_multinode_args = {}):
+        farm = fake_multinode_args.get("farm")
+        max_timeout_s = fake_multinode_args.get("max_timeout_s")
+        sb = self._get_sandbox(farm)
+        node_name = sb["host_container"]
+
+        ovn_sbctl = self.controller_client("ovn-sbctl")
+        ovn_sbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
+        ovn_sbctl.enable_batch_mode(False)
+        self._wait_chassis(ovn_sbctl, node_name, max_timeout_s)
+
+    @scenario.configure(context={})
+    def del_chassis_node(self, fake_multinode_args = {}):
+        farm = fake_multinode_args.get("farm")
+        sb = self._get_sandbox(farm)
+        ssh = self._get_sandbox_conn(sb["name"], sb)
+
+        node_name = sb["host_container"]
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+        self._del_chassis(ssh, node_name, ovn_fake_path)
+
+    @scenario.configure(context={})
+    def del_central_node(self, fake_multinode_args = {}):
+        ssh = self.controller_client("ovs-ssh")
+        ssh.set_sandbox("controller-sandbox", self.install_method)
+        ssh.enable_batch_mode(False)
+
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+        self._del_central(ssh, ovn_fake_path)

--- a/samples/tasks/scenarios/ovn-network/deploy_fake_multinode.json
+++ b/samples/tasks/scenarios/ovn-network/deploy_fake_multinode.json
@@ -1,0 +1,186 @@
+{% set farm_nodes = farm_nodes or 1 %}
+{
+    "version": 2,
+    "title": "Create farm sandboxes",
+    "subtasks": [
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Create sandbox on farm {{i}}",
+            "workloads": [{
+                "name": "OvnSandbox.create_sandbox",
+                "args": {
+                    "sandbox_create_args": {
+                        "farm": "ovn-farm-node-{{i}}",
+                        "amount": 1,
+                        "batch" : 1,
+                        "start_cidr": "192.168.42.{{i + 10}}/24",
+                        "net_dev": "eth1",
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": 1},
+                "context": {
+                    "ovn_multihost": {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {% endfor %}
+        {
+            "title": "Deploy central node",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.add_central_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "node_net": "192.16.0.0",
+                            "node_net_len": "16",
+                            "node_ip": "192.16.1.2",
+                            "cluster_cmd_path": "/root/ovn-fake-multinode"
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Deploy chassis nodes",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.add_chassis_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "farm": "ovn-farm-node-{{i}}",
+                            "node_net": "192.16.0.0",
+                            "node_net_len": "16",
+                            "node_ip": "192.16.{{(i+1)//256}}.{{(i+1)%256}}",
+                            "cluster_cmd_path": "/root/ovn-fake-multinode"
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% endfor %}
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Connect chassis nodes",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.connect_chassis_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "farm": "ovn-farm-node-{{i}}",
+                            "central_ip": "192.16.1.2",
+                            "cluster_cmd_path": "/root/ovn-fake-multinode"
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% endfor %}
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Wait chassis nodes",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.wait_chassis_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "farm": "ovn-farm-node-{{i}}",
+                            "max_timeout_s": 60
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% endfor %}
+        {% for i in range(0, farm_nodes) %}
+        {
+            "title": "Stop chassis nodes",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.del_chassis_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "farm": "ovn-farm-node-{{i}}",
+                            "cluster_cmd_path": "/root/ovn-fake-multinode"
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% endfor %}
+        {
+            "title": "Stop central node",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.del_central_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "cluster_cmd_path": "/root/ovn-fake-multinode"
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+    ]
+}


### PR DESCRIPTION
This commit adds a new type of scenario (OvnFakeMultinode) which allows
users to add/connect central/chassis nodes to a cluster topology created
by ovn-fake-multinode: https://github.com/ovn-org/ovn-fake-multinode

Prerequisites are that ovn-fake-multinode is already available on target
nodes.

For a sample scenario definition please have a look at:
samples/tasks/scenarios/ovn-network/deploy_fake_multinode.json.
The scenario:
- deploys a central OVN node and 'farm_nodes' chassis nodes.
- connects the chassis nodes to the central nodes (by setting the
  "ovn-remote" configuration).
- waits until all chassis have created their corresponding record in the
  OVN SB Chassis table.
- destroys the chassis and central nodes.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>