### PR TITLE
OpenShift workload

### DIFF
--- a/rally_ovs/plugins/ovs/context/datapath.py
+++ b/rally_ovs/plugins/ovs/context/datapath.py
@@ -89,6 +89,7 @@ class Datapath(ovnclients.OvnClientMixin, context.Context):
             "routers": routers,
             "lswitches": lswitches,
         }
+        self.context["ovs-internal-ports"] = {}
 
     def cleanup(self):
         pass  # Not implemented

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -67,6 +67,11 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         lswitches = []
         for i in range(num_switches):
             name = self.generate_random_name()
+            if start_cidr:
+                cidr = start_cidr.next(i)
+                name = "lswitch_%s" % cidr
+            else:
+                name = self.generate_random_name()
 
             other_cfg = {
                 'mcast_snoop': mcast_snoop,
@@ -76,7 +81,7 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
 
             lswitch = ovn_nbctl.lswitch_add(name, other_cfg)
             if start_cidr:
-                lswitch["cidr"] = start_cidr.next(i)
+                lswitch["cidr"] = cidr
 
             LOG.info("create %(name)s %(cidr)s" % \
                       {"name": name, "cidr": lswitch.get("cidr", "")})

--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -15,6 +15,8 @@
 import abc
 import collections
 import six
+import re
+import netaddr
 
 from rally.common.plugin import plugin
 from rally.task import scenario
@@ -139,8 +141,13 @@ def get_lswitch_info(info):
     for line in info.splitlines():
         tokens = line.strip().split(" ")
         if tokens[0] == "switch":
+            start_cidr = re.sub("\(lswitch_|\)", "", tokens[2])
+            if len(start_cidr):
+                cidr = netaddr.IPNetwork(start_cidr)
+            else:
+                cidr = ""
             name = tokens[2][1:-1]
-            lswitch = {"name":name, "uuid":tokens[1], "lports":[]}
+            lswitch = {"name":name, "uuid":tokens[1], "lports":[], "cidr":cidr}
             lswitches.append(lswitch)
         elif tokens[0] == "port":
             name = tokens[1][1:-1]

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -19,7 +19,6 @@ from io import StringIO
 from rally_ovs.plugins.ovs.ovsclients import *
 from rally_ovs.plugins.ovs.utils import get_ssh_from_credential
 
-
 @configure("ssh")
 class SshClient(OvsClient):
 
@@ -158,6 +157,16 @@ class OvnNbctl(OvsClient):
             self.run("ls-list", stdout=stdout)
             output = stdout.getvalue()
             return parse_lswitch_list(output)
+
+        def lrouter_list(self):
+            stdout = StringIO()
+            self.run("lr-list", stdout=stdout)
+            output = stdout.getvalue()
+            return parse_lswitch_list(output)
+
+        def lrouter_del(self, name):
+            params = [name]
+            self.run("lr-del", args=params)
 
         def lswitch_port_add(self, lswitch, name, mac='', ip=''):
             params =[lswitch, name]
@@ -458,7 +467,7 @@ class OvsVsctl(OvsClient):
             self.install_method = install_method
             self.host_container = host_container
 
-        def run(self, cmd, opts=[], args=[], extras=[]):
+        def run(self, cmd, opts=[], args=[], extras=[], stdout=sys.stdout, stderr=sys.stderr):
             self.cmds = self.cmds or []
 
             # TODO: tested with non batch_mode only for docker
@@ -485,8 +494,7 @@ class OvsVsctl(OvsClient):
             if self.batch_mode:
                 return
 
-            self.ssh.run("\n".join(self.cmds),
-                         stdout=sys.stdout, stderr=sys.stderr)
+            self.ssh.run("\n".join(self.cmds), stdout=stdout, stderr=stderr)
 
             self.cmds = None
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
@@ -12,15 +12,124 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
+import netaddr
+import random
+import re
+import copy
 
 from rally_ovs.plugins.ovs.scenarios import ovn
 
 from rally.task import scenario
+from rally.task import atomic
 from rally.task import validation
 
 class OvnNorthbound(ovn.OvnScenario):
     """Benchmark scenarios for OVN northbound."""
+
+    @scenario.configure()
+    def create_routed_network(self, lswitch_create_args = None,
+                              networks_per_router = None,
+                              lport_create_args = None,
+                              port_bind_args = None,
+                              create_mgmt_port = True):
+        lrouters = self.context["datapaths"]["routers"]
+        iteration = self.context["iteration"]
+        sandboxes = self.context["sandboxes"]
+
+        lswitch_args = copy.copy(lswitch_create_args)
+        start_cidr = lswitch_create_args.get("start_cidr", "")
+        if start_cidr:
+            start_cidr = netaddr.IPNetwork(start_cidr)
+            cidr = start_cidr.next(iteration)
+            lswitch_args["start_cidr"] = str(cidr)
+        lswitches = self._create_lswitches(lswitch_args)
+
+        if networks_per_router:
+            self._connect_networks_to_routers(lswitches, lrouters,
+                                              networks_per_router)
+
+        if create_mgmt_port == False:
+            return
+
+        sandbox = sandboxes[iteration % len(sandboxes)]
+        lport = self._create_lports(lswitches[0], lport_create_args)
+        self._bind_ports_and_wait(lport, [sandbox], port_bind_args)
+
+    @atomic.action_timer("ovn.create_or_update_address_set")
+    def create_or_update_address_set(self, name, ipaddr, create = True):
+        if (create):
+            self._create_address_set(name, ipaddr)
+        else:
+            self._address_set_add_addrs(name, ipaddr)
+
+    @atomic.action_timer("ovn.create_port_acls")
+    def create_port_acls(self, lswitch, lports, addr_set):
+        """
+        create two acl for each logical port
+        prio 1000: allow inter project traffic
+        prio 900: deny all
+        """
+        match = "%(direction)s == \"%(lport)s\" && ip4.dst == %(address_set)s"
+        acl_create_args = { "match" : match, "address_set" : addr_set }
+        self._create_acl(lswitch, lports, acl_create_args, 1,
+                         atomic_action = False)
+        acl_create_args = { "priority" : 900, "action" : "drop", "match" : "%(direction)s == \"%(lport)s\" && ip4" }
+        self._create_acl(lswitch, lports, acl_create_args, 1,
+                         atomic_action = False)
+
+    def create_lport_acl_addrset(self, lswitch, lport_create_args, port_bind_args,
+                                 ip_start_index = 0, addr_set_index = 0,
+                                 create_addr_set = True, create_acls = True):
+        lports = self._create_lports(lswitch, lport_create_args,
+                                     lport_ip_shift = ip_start_index)
+
+        if create_acls:
+            network_cidr = lswitch.get("cidr", None)
+            if network_cidr:
+                ip_list = netaddr.IPNetwork(network_cidr.ip + ip_start_index).iter_hosts()
+                ipaddr = str(next(ip_list))
+            else:
+                ipaddr = ""
+            self.create_or_update_address_set("addrset%d" % addr_set_index,
+                                              ipaddr, create_addr_set)
+
+            self.create_port_acls(lswitch, lports,
+                                  "$addrset%d" % addr_set_index)
+
+        sandboxes = self.context["sandboxes"]
+        sandbox = sandboxes[self.context["iteration"] % len(sandboxes)]
+        self._bind_ports_and_wait(lports, [sandbox], port_bind_args)
+
+    @scenario.configure()
+    def create_routed_lport(self, lport_create_args = None,
+                            port_bind_args = None,
+                            create_acls = True,
+                            address_set_size = 1):
+        lswitches = self.context["ovn-nb"]
+        ip_offset = lport_create_args.get("ip_offset", 1) if lport_create_args else 1
+        address_set_size = 1 if address_set_size == 0 else address_set_size
+
+        iteration = self.context["iteration"]
+        lswitch = lswitches[iteration % len(lswitches)]
+        addr_set_index = iteration / address_set_size
+        ip_start_index = iteration / len(lswitches) + ip_offset
+
+        self.create_lport_acl_addrset(lswitch, lport_create_args,
+                                      port_bind_args, ip_start_index,
+                                      addr_set_index,
+                                      (iteration % address_set_size) == 0,
+                                      create_acls)
+
+    @scenario.configure(context={})
+    def cleanup_routed_lswitches(self):
+        sandboxes = self.context.get("sandboxes", [])
+        for sandbox in sandboxes:
+            self._flush_ovs_internal_ports(sandbox)
+        lswitches = self.context.get("ovn-nb", [])
+        self._delete_lswitch(lswitches)
+        self._delete_routers()
+        for address_set in self._list_address_set():
+            self._remove_address_set(address_set)
 
     @scenario.configure(context={})
     def create_and_list_lswitches(self, lswitch_create_args=None):

--- a/samples/tasks/scenarios/ovn-network/osh_workload.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload.json
@@ -1,0 +1,135 @@
+{% set farm_nodes = farm_nodes or 1 %}
+{% set networks = networks or 1 %}
+{% set ports_per_network = ports_per_network or 1 %}
+{
+    "version": 2,
+    "title": "OpenShift switch per node workload",
+    "subtasks": [
+        {
+            "title": "Delete sandbox all sandboxes with tag 'ToR1'",
+            "workloads": [{
+                "name": "OvnSandbox.delete_sandbox",
+                "args": {
+                    "sandbox_delete_args": {
+                        "graceful": false,
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": 1},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {
+            "title": "Create sandboxes",
+            "workloads": [{
+                "name": "OvnSandbox.create_sandbox",
+                "args": {
+                    "sandbox_create_args": {
+                        "farm-prefix": "ovn-farm-node-",
+                        "amount": 1,
+                        "batch" : 1,
+                        "net_dev": "eth1",
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": {{farm_nodes}}},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {
+            "title": "cleanup ovn osh configuration",
+            "workloads": [{
+                "name": "OvnNorthbound.cleanup_routed_lswitches",
+                "runner": {"type": "serial","times": 1},
+                "context": {
+                   "sandbox": {"tag": "ToR1"},
+                   "ovn_multihost" : {"controller": "ovn-controller-node"},
+                   "ovn_nb": {}
+                }
+            }]
+        },
+        {
+            "title": "Create switch-per-node scenario (setup workload)",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.create_routed_network",
+                    "args": {
+                        "lswitch_create_args": {
+                            "start_cidr": "1.0.0.0/16"
+                        },
+                        "lport_create_args": {
+                            "batch" : 1,
+                            "port_security" : true
+                        },
+                        "port_bind_args": {
+                            "internal" : true,
+                            "wait_up" : true,
+                            "batch" : false
+                        },
+                        "networks_per_router": {{networks}}
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": {{networks}}
+                    },
+                    "context": {
+                        "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": {"tag": "ToR1"},
+                        "datapath": {
+                            "router_create_args": {
+                                "amount": 1
+                            }
+                        },
+                        "ovn-nbctld" : {
+                            "daemon_mode": True
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Create switch-per-node scenario (add pods workload)",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.create_routed_lport",
+                    "args": {
+                        "lport_create_args": {
+                            "batch" : 1,
+                            "port_security" : true,
+                            "ip_offset" : 2
+                        },
+                        "port_bind_args": {
+                            "internal" : true,
+                            "wait_up" : true,
+                            "batch" : false
+                        },
+                        "address_set_size": 2,
+                        "create_acls": true
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": {{ports_per_network}}
+                    },
+                    "context": {
+                       "sandbox": {"tag": "ToR1"},
+                       "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                       },
+                       "ovn_nb": {},
+                       "ovn-nbctld" : {
+                            "daemon_mode": True
+                       }
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Introduce osh workload in order to simulate a typical OpenShift deployment:
- 1 logical router, 'n' logical switches each with 'm' logical switch ports
- address_set for each couple of logical switch port
- 2 acls for each logical switch port