### PR TITLE
Add Openshift-like 'switch per node' bring-up scenario.

### DIFF
--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -55,7 +55,7 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         if start_cidr:
             start_cidr = netaddr.IPNetwork(start_cidr)
 
-        mcast_snoop = lswitch_create_args.get("mcast_snoop", "true")
+        mcast_snoop = lswitch_create_args.get("mcast_snoop", "false")
         mcast_idle = lswitch_create_args.get("mcast_idle_timeout", 300)
         mcast_table_size = lswitch_create_args.get("mcast_table_size", 2048)
 

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -168,11 +168,11 @@ class OvnNbctl(OvsClient):
             params = [name]
             self.run("lr-del", args=params)
 
-        def lswitch_port_add(self, lswitch, name, mac='', ip=''):
+        def lswitch_port_add(self, lswitch, name, mac='', ip='', gw=''):
             params =[lswitch, name]
             self.run("lsp-add", args=params)
 
-            return {"name":name, "mac":mac, "ip":ip}
+            return {"name":name, "mac":mac, "ip":ip, "gw":gw}
 
 
         def lport_list(self, lswitch):

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -136,8 +136,9 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
                 name = self.generate_random_name()
             mac = utils.get_random_mac(base_mac)
             ip_mask = '{}/{}'.format(ip, network_cidr.prefixlen)
+            gw = str(self._get_gw_ip(network_cidr))
             lport = ovn_nbctl.lswitch_port_add(lswitch["name"], name, mac,
-                                               ip_mask)
+                                               ip_mask, gw)
 
             ovn_nbctl.lport_set_addresses(name, [mac, ip])
             if port_security:

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -18,6 +18,7 @@ from rally.common import logging
 from rally import exceptions
 from rally_ovs.plugins.ovs import ovnclients
 from rally_ovs.plugins.ovs import utils
+import copy
 import random
 import netaddr
 from io import StringIO
@@ -356,6 +357,34 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             self._create_phynet(lswitches, physnet, batch)
 
         return lswitches
+
+    def _create_routed_network(self, lswitch_create_args = {},
+                               networks_per_router = {},
+                               lport_create_args = {},
+                               port_bind_args = {},
+                               create_mgmt_port = True):
+        lrouters = self.context["datapaths"]["routers"]
+        iteration = self.context["iteration"]
+        sandboxes = self.context["sandboxes"]
+
+        lswitch_args = copy.copy(lswitch_create_args)
+        start_cidr = lswitch_create_args.get("start_cidr", "")
+        if start_cidr:
+            start_cidr = netaddr.IPNetwork(start_cidr)
+            cidr = start_cidr.next(iteration)
+            lswitch_args["start_cidr"] = str(cidr)
+        lswitches = self._create_lswitches(lswitch_args)
+
+        if networks_per_router:
+            self._connect_networks_to_routers(lswitches, lrouters,
+                                              networks_per_router)
+
+        if create_mgmt_port == False:
+            return
+
+        sandbox = sandboxes[iteration % len(sandboxes)]
+        lport = self._create_lports(lswitches[0], lport_create_args)
+        self._bind_ports_and_wait(lport, [sandbox], port_bind_args)
 
     def _bind_ports_and_wait(self, lports, sandboxes, port_bind_args):
         port_bind_args = port_bind_args or {}

--- a/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
@@ -16,6 +16,7 @@ from rally_ovs.plugins.ovs.scenarios import ovn
 from rally.task import atomic
 from rally.task import scenario
 import time
+import netaddr
 
 """Scenario to dynamically add/delete ovn nodes running in containers.
 
@@ -41,52 +42,60 @@ class OvnFakeMultinode(ovn.OvnScenario):
         ssh.enable_batch_mode(False)
         return ssh
 
-    @atomic.action_timer("OvnFakeMultinode.add_central_node")
     def _add_central(self, ssh_conn, node_net, node_net_len, node_ip,
-                     ovn_fake_path):
-        cmd = "cd {} && CHASSIS_COUNT=0 GW_COUNT=0 IP_HOST={} IP_CIDR={} IP_START={} ./ovn_cluster.sh start || true".format(
-            ovn_fake_path, node_net, node_net_len, node_ip
+                     ovn_fake_path, monitor_all=False):
+        if monitor_all:
+            monitor_cmd = "OVN_MONITOR_ALL=yes"
+        else:
+            monitor_cmd = "OVN_MONITOR_ALL=no"
+
+        cmd = "cd {} && CHASSIS_COUNT=0 GW_COUNT=0 IP_HOST={} IP_CIDR={} IP_START={} {} CREATE_FAKE_VMS=no ./ovn_cluster.sh start".format(
+            ovn_fake_path, node_net, node_net_len, node_ip, monitor_cmd
         )
         ssh_conn.run(cmd)
 
-    @atomic.action_timer("OvnFakeMultinode.add_chassis_node")
+        time.sleep(5)
+
     def _add_chassis(self, ssh_conn, node_net, node_net_len, node_ip, node_name,
-                     ovn_fake_path):
+                     ovn_fake_path, monitor_all=False):
         invalid_remote = "tcp:0.0.0.1:6642"
-        cmd = "cd {} && IP_HOST={} IP_CIDR={} IP_START={} ./ovn_cluster.sh add-chassis {} {} || true".format(
-            ovn_fake_path, node_net, node_net_len, node_ip, node_name, invalid_remote
+        if monitor_all:
+            monitor_cmd = "OVN_MONITOR_ALL=yes"
+        else:
+            monitor_cmd = "OVN_MONITOR_ALL=no"
+
+        cmd = "cd {} && IP_HOST={} IP_CIDR={} IP_START={} {} ./ovn_cluster.sh add-chassis {} {}".format(
+            ovn_fake_path, node_net, node_net_len, node_ip, monitor_cmd,
+            node_name, invalid_remote
         )
         ssh_conn.run(cmd)
 
-    @atomic.action_timer("OvnFakeMultinode.connect_chassis_node")
     def _connect_chassis(self, ssh_conn, node_name, central_ip, ovn_fake_path):
-        cmd = "cd {} && ./ovn_cluster.sh set-chassis-ovn-remote {} tcp:{}:6642 || true".format(
+        cmd = "cd {} && ./ovn_cluster.sh set-chassis-ovn-remote {} tcp:{}:6642".format(
             ovn_fake_path, node_name, central_ip
         )
         ssh_conn.run(cmd)
 
-    @atomic.action_timer("ovnFakeMultinode.wait_chassis_node")
     def _wait_chassis(self, sbctl_conn, chassis_name, max_timeout_s):
         for i in range(0, max_timeout_s * 10):
             if sbctl_conn.chassis_bound(chassis_name):
                 break
             time.sleep(0.1)
 
-    @atomic.action_timer("OvnFakeMultinode.del_chassis_node")
     def _del_chassis(self, ssh_conn, node_name, ovn_fake_path):
-        cmd = "cd {} && ./ovn_cluster.sh stop-chassis {} || true".format(
+        cmd = "cd {} && OVN_BR_CLEANUP=no ./ovn_cluster.sh stop-chassis {}".format(
             ovn_fake_path, node_name
         )
         ssh_conn.run(cmd)
 
-    @atomic.action_timer("OvnFakeMultinode.del_central_node")
     def _del_central(self, ssh_conn, ovn_fake_path):
-        cmd = "cd {} && CHASSIS_COUNT=0 GW_COUNT=0 ./ovn_cluster.sh stop || true".format(
+        cmd = "cd {} && CHASSIS_COUNT=0 GW_COUNT=0 OVN_BR_CLEANUP=no ./ovn_cluster.sh stop".format(
             ovn_fake_path
         )
         ssh_conn.run(cmd)
 
     @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.add_central_node")
     def add_central_node(self, fake_multinode_args = {}):
         ssh = self.controller_client("ovs-ssh")
         ssh.set_sandbox("controller-sandbox", self.install_method)
@@ -96,10 +105,13 @@ class OvnFakeMultinode(ovn.OvnScenario):
         node_net_len = fake_multinode_args.get("node_net_len")
         node_ip = fake_multinode_args.get("node_ip")
         ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+        monitor_all = fake_multinode_args.get("ovn_monitor_all")
 
-        self._add_central(ssh, node_net, node_net_len, node_ip, ovn_fake_path)
+        self._add_central(ssh, node_net, node_net_len, node_ip, ovn_fake_path,
+                          monitor_all)
 
     @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.add_chassis_node")
     def add_chassis_node(self, fake_multinode_args = {}):
         farm = fake_multinode_args.get("farm")
         sb = self._get_sandbox(farm)
@@ -110,10 +122,13 @@ class OvnFakeMultinode(ovn.OvnScenario):
         node_ip = fake_multinode_args.get("node_ip")
         node_name = sb["host_container"]
         ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+        monitor_all = fake_multinode_args.get("ovn_monitor_all")
+
         self._add_chassis(ssh, node_net, node_net_len, node_ip, node_name,
-                          ovn_fake_path)
+                          ovn_fake_path, monitor_all)
 
     @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.connect_chassis_node")
     def connect_chassis_node(self, fake_multinode_args = {}):
         farm = fake_multinode_args.get("farm")
         sb = self._get_sandbox(farm)
@@ -125,9 +140,10 @@ class OvnFakeMultinode(ovn.OvnScenario):
         self._connect_chassis(ssh, node_name, central_ip, ovn_fake_path)
 
     @scenario.configure(context={})
+    @atomic.action_timer("ovnFakeMultinode.wait_chassis_node")
     def wait_chassis_node(self, fake_multinode_args = {}):
         farm = fake_multinode_args.get("farm")
-        max_timeout_s = fake_multinode_args.get("max_timeout_s")
+        max_timeout_s = fake_multinode_args.get("max_timeout_s", 60)
         sb = self._get_sandbox(farm)
         node_name = sb["host_container"]
 
@@ -138,6 +154,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
         self._wait_chassis(ovn_sbctl, node_name, max_timeout_s)
 
     @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.del_chassis_node")
     def del_chassis_node(self, fake_multinode_args = {}):
         farm = fake_multinode_args.get("farm")
         sb = self._get_sandbox(farm)
@@ -148,6 +165,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
         self._del_chassis(ssh, node_name, ovn_fake_path)
 
     @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.del_central_node")
     def del_central_node(self, fake_multinode_args = {}):
         ssh = self.controller_client("ovs-ssh")
         ssh.set_sandbox("controller-sandbox", self.install_method)
@@ -155,3 +173,115 @@ class OvnFakeMultinode(ovn.OvnScenario):
 
         ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
         self._del_central(ssh, ovn_fake_path)
+
+    @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.add_chassis_nodes")
+    def add_chassis_nodes(self, fake_multinode_args = {}):
+        iteration = self.context["iteration"]
+        batch_size = fake_multinode_args.get("batch_size", 1)
+        node_prefix = fake_multinode_args.get("node_prefix", "")
+
+        node_net = fake_multinode_args.get("node_net")
+        node_net_len = fake_multinode_args.get("node_net_len")
+        node_cidr = netaddr.IPNetwork("{}/{}".format(node_net, node_net_len))
+
+        monitor_all = fake_multinode_args.get("ovn_monitor_all")
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+
+        for i in range(batch_size):
+            index = iteration * batch_size + i
+            node_ip = str(node_cidr.ip + index + 1)
+
+            farm = "{}{}".format(node_prefix, index % len(self._sandboxes))
+            sb = self._get_sandbox(farm)
+            ssh = self._get_sandbox_conn(sb["name"], sb)
+            node_name = sb["host_container"]
+
+            self._add_chassis(ssh, node_net, node_net_len, node_ip, node_name,
+                              ovn_fake_path, monitor_all)
+
+    @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.connect_chassis_nodes")
+    def connect_chassis_nodes(self, fake_multinode_args = {}):
+        iteration = self.context["iteration"]
+        batch_size = fake_multinode_args.get("batch_size", 1)
+        node_prefix = fake_multinode_args.get("node_prefix", "")
+
+        central_ip = fake_multinode_args.get("central_ip")
+        ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+
+        for i in range(batch_size):
+            index = iteration * batch_size + i
+
+            farm = "{}{}".format(node_prefix, index % len(self._sandboxes))
+            sb = self._get_sandbox(farm)
+            ssh = self._get_sandbox_conn(sb["name"], sb)
+            node_name = sb["host_container"]
+
+            self._connect_chassis(ssh, node_name, central_ip, ovn_fake_path)
+
+    @scenario.configure(context={})
+    @atomic.action_timer("ovnFakeMultinode.wait_chassis_nodes")
+    def wait_chassis_nodes(self, fake_multinode_args = {}):
+        iteration = self.context["iteration"]
+        batch_size = fake_multinode_args.get("batch_size", 1)
+        node_prefix = fake_multinode_args.get("node_prefix", "")
+        max_timeout_s = fake_multinode_args.get("max_timeout_s")
+
+        ovn_sbctl = self.controller_client("ovn-sbctl")
+        ovn_sbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
+        ovn_sbctl.enable_batch_mode(False)
+        for i in range(batch_size):
+            index = iteration * batch_size + i
+
+            farm = "{}{}".format(node_prefix, index % len(self._sandboxes))
+            sb = self._get_sandbox(farm)
+            ssh = self._get_sandbox_conn(sb["name"], sb)
+            node_name = sb["host_container"]
+
+            self._wait_chassis(ovn_sbctl, node_name, max_timeout_s)
+
+    @scenario.configure(context={})
+    @atomic.action_timer("OvnFakeMultinode.del_chassis_nodes")
+    def del_chassis_nodes(self, fake_multinode_args = {}):
+        iteration = self.context["iteration"]
+        batch_size = fake_multinode_args.get("batch_size", 1)
+        node_prefix = fake_multinode_args.get("node_prefix", "")
+
+        for i in range(batch_size):
+            index = iteration * batch_size + i
+
+            farm = "{}{}".format(node_prefix, index % len(self._sandboxes))
+            sb = self._get_sandbox(farm)
+            ssh = self._get_sandbox_conn(sb["name"], sb)
+
+            ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
+            node_name = sb["host_container"]
+
+            self._del_chassis(ssh, node_name, ovn_fake_path)
+
+
+class OvnNorthboundFakeMultinode(OvnFakeMultinode):
+
+    def __init__(self, context):
+        super(OvnNorthboundFakeMultinode, self).__init__(context)
+
+    @scenario.configure(context={})
+    def setup_switch_per_node(self, fake_multinode_args = {},
+                              lswitch_create_args = {},
+                              networks_per_router = {},
+                              lport_create_args = {},
+                              port_bind_args = {},
+                              create_mgmt_port = True):
+        self.add_chassis_nodes(fake_multinode_args)
+        self.connect_chassis_nodes(fake_multinode_args)
+        self.wait_chassis_nodes(fake_multinode_args)
+
+        lswitch_create_args['amount'] = fake_multinode_args.get('batch_size', 1)
+        lswitch_create_args['batch'] = 1
+        self._create_routed_network(lswitch_create_args=lswitch_create_args,
+                                    networks_per_router=networks_per_router,
+                                    lport_create_args=lport_create_args,
+                                    port_bind_args=port_bind_args,
+                                    create_mgmt_port=create_mgmt_port)

--- a/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
@@ -224,8 +224,9 @@ class OvnIGMP(ovn_network.OvnNetwork):
             self._cleanup_mcast_tests()
 
         for lswitch in lswitches:
-            switch_lports = self._create_lports(lswitch, port_create_args,
-                                                ports_per_network)
+            switch_lports = self._create_switch_lports(lswitch,
+                                                       port_create_args,
+                                                       ports_per_network)
             lports_per_lswitch[lswitch["name"]] = switch_lports
             lports += switch_lports
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
@@ -73,8 +73,8 @@ class OvnNorthbound(ovn.OvnScenario):
     def configure_routed_lport(self, lswitch, lport_create_args, port_bind_args,
                                ip_start_index = 0, address_set_size = 1,
                                port_group_size = 1, create_acls = True):
-        lports = self._create_lport(lswitch, lport_create_args,
-                                    lport_ip_shift = ip_start_index)
+        lports = self._create_switch_lports(lswitch, lport_create_args,
+                                            lport_ip_shift = ip_start_index)
 
         if create_acls:
             network_cidr = lswitch.get("cidr", None)
@@ -173,9 +173,7 @@ class OvnNorthbound(ovn.OvnScenario):
                               lports_per_lswitch=None):
 
         lswitches = self._create_lswitches(lswitch_create_args)
-
-        for lswitch in lswitches:
-            self._create_lports(lswitch, lport_create_args, lports_per_lswitch)
+        self._create_lports(lswitches, lport_create_args, lports_per_lswitch)
 
         self._list_lports(lswitches)
 
@@ -187,11 +185,9 @@ class OvnNorthbound(ovn.OvnScenario):
                               lports_per_lswitch=None):
 
         lswitches = self._create_lswitches(lswitch_create_args)
-        for lswitch in lswitches:
-            lports = self._create_lports(lswitch, lport_create_args,
-                                        lports_per_lswitch)
-            self._delete_lport(lports)
-
+        lports = self._create_lports(lswitches, lport_create_args,
+                                     lports_per_lswitch)
+        self._delete_lport(lports)
         self._delete_lswitch(lswitches)
 
 
@@ -205,7 +201,8 @@ class OvnNorthbound(ovn.OvnScenario):
         if lswitch_create_args != None:
             lswitches = self._create_lswitches(lswitch_create_args)
             for lswitch in lswitches:
-                lports = self._create_lports(lswitch, lport_create_args,
+                lports = self._create_switch_lports(lswitch,
+                                                    lport_create_args,
                                                     lports_per_lswitch)
                 lswitch["lports"] = lports
         else:

--- a/rally_ovs/plugins/ovs/scenarios/ovn_network.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_network.py
@@ -74,11 +74,10 @@ class OvnNetwork(ovn.OvnScenario):
             # when there is no sandbox specified, bind on all sandboxes.
             sandboxes = utils.get_sandboxes(self.task["deployment_uuid"])
 
-        for network in lnetworks:
-            lports = self._create_lports(network, port_create_args, ports_per_network)
-            if (len(lports) < len(sandboxes)):
-                LOG.warn("Number of ports less than chassis: random binding\n")
-            self._bind_ports_and_wait(lports, sandboxes, port_bind_args)
+        lports = self._create_lports(lnetworks, port_create_args, ports_per_network)
+        if (len(lports) < len(sandboxes)):
+            LOG.warn("Number of ports less than chassis: random binding\n")
+        self._bind_ports_and_wait(lports, sandboxes, port_bind_args)
 
 
     @validation.number("ports_per_network", minval=1, integer_only=True)
@@ -109,11 +108,8 @@ class OvnNetwork(ovn.OvnScenario):
                     if start_cidr:
                         lswitches[i]["cidr"] = start_cidr.next(i)
 
-        lports = []
-
-        for lswitch in lswitches:
-            lports += self._create_lports(lswitch, port_create_args, ports_per_network)
-
+        lports = self._create_lports(lswitches, port_create_args,
+                                     ports_per_network)
         self._bind_ports_and_wait(lports, sandboxes, port_bind_args)
 
         if internal_ports_cleanup:

--- a/rally_ovs/plugins/ovs/scenarios/sandbox.py
+++ b/rally_ovs/plugins/ovs/scenarios/sandbox.py
@@ -114,7 +114,7 @@ class SandboxScenario(scenario.OvsScenario):
         ssh.run("\n".join(cmds), stdout=sys.stdout, stderr=sys.stderr);
 
 
-    def _create_sandbox(self, sandbox_create_args):
+    def _create_sandbox(self, sandbox_create_args, farm=None):
         """
         :param sandbox_create_args from task config file
         """
@@ -124,7 +124,8 @@ class SandboxScenario(scenario.OvsScenario):
         amount = sandbox_create_args.get("amount", 1)
         batch = sandbox_create_args.get("batch", 1)
 
-        farm = sandbox_create_args.get("farm")
+        if not farm:
+            farm = sandbox_create_args.get("farm")
         controller_ip = self.context["controller"]["ip"]
 
         start_cidr = sandbox_create_args.get("start_cidr")

--- a/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
@@ -1,0 +1,253 @@
+{% set max_farm_nodes = max_farm_nodes or 1 %}
+{% set farm_nodes = farm_nodes or 1 %}
+{% set ports_per_network = ports_per_network or 1 %}
+{% set ovn_monitor_all = ovn_monitor_all or false %}
+{% set cluster_cmd_path = cluster_cmd_path or "/root/ovn-fake-testing/ovn-fake-multinode" %}
+{% set node_batch_size = node_batch_size or 1 %}
+{% set sla = sla or 30 %}
+{
+    "version": 2,
+    "title": "Switch per node workload",
+    "subtasks": [
+        {
+            "title": "Delete sandbox all sandboxes with tag 'ToR1'",
+            "workloads": [{
+                "name": "OvnSandbox.delete_sandbox",
+                "args": {
+                    "sandbox_delete_args": {
+                        "graceful": false,
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": 1},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {
+            "title": "Create sandboxes",
+            "workloads": [{
+                "name": "OvnSandbox.create_sandbox",
+                "args": {
+                    "sandbox_create_args": {
+                        "farm-prefix": "ovn-farm-node-",
+                        "amount": 1,
+                        "batch" : 1,
+                        "net_dev": "eth1",
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": {{max_farm_nodes}}},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {
+            "title": "Delete all chassis nodes",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.del_chassis_nodes",
+                    "args": {
+                        "fake_multinode_args": {
+                            "node_prefix": "ovn-farm-node-",
+                            "cluster_cmd_path": {{cluster_cmd_path}}
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": {{max_farm_nodes}}
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "ovn_nb": {},
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Delete central node",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.del_central_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "cluster_cmd_path": {{cluster_cmd_path}}
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Delete sandbox all sandboxes with tag 'ToR1'",
+            "workloads": [{
+                "name": "OvnSandbox.delete_sandbox",
+                "args": {
+                    "sandbox_delete_args": {
+                        "graceful": false,
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": 1},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {
+            "title": "Create sandboxes",
+            "workloads": [{
+                "name": "OvnSandbox.create_sandbox",
+                "args": {
+                    "sandbox_create_args": {
+                        "farm-prefix": "ovn-farm-node-",
+                        "amount": 1,
+                        "batch" : 1,
+                        "net_dev": "eth1",
+                        "tag": "ToR1"
+                    }
+                },
+                "runner": {"type": "serial", "times": {{farm_nodes}}},
+                "context": {
+                    "ovn_multihost" : {"controller": "ovn-controller-node"}
+                }
+            }]
+        },
+        {
+            "title": "Deploy central node",
+            "workloads": [
+                {
+                    "name": "OvnFakeMultinode.add_central_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "node_net": "192.16.0.0",
+                            "node_net_len": "16",
+                            "node_ip": "192.16.0.1",
+                            "cluster_cmd_path": {{cluster_cmd_path}},
+                            "ovn_monitor_all": {{ovn_monitor_all}}
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Create switch-per-node scenario (setup workload)",
+            "workloads": [
+                {
+                    "name": "OvnNorthboundFakeMultinode.setup_switch_per_node",
+                    "args": {
+                        "fake_multinode_args": {
+                            "node_net": "192.16.0.0",
+                            "node_net_len": "16",
+                            "node_prefix": "ovn-farm-node-",
+                            "central_ip": "192.16.0.1",
+                            "cluster_cmd_path": {{cluster_cmd_path}},
+                            "ovn_monitor_all": {{ovn_monitor_all}},
+                            "max_timeout_s": 10,
+                            "batch_size": {{node_batch_size}}
+                        },
+                        "lswitch_create_args": {
+                            "start_cidr": "1.0.0.0/16"
+                        },
+                        "lport_create_args": {
+                            "port_security" : true
+                        },
+                        "port_bind_args": {
+                            "internal" : true,
+                            "wait_up" : true,
+                            "wait_sync" : "ping",
+                            "batch" : false
+                        },
+                        "networks_per_router": {{farm_nodes}}
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": {{farm_nodes // node_batch_size}}
+                    },
+                    "sla": {
+                        "max_seconds_per_iteration": {{sla}}
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "ovn_nb": {},
+                        "sandbox": { "tag": "ToR1" },
+                        "datapath": {
+                            "router_create_args": {
+                                "amount": 1
+                            }
+                        },
+                        "ovn-nbctld" : {
+                            "daemon_mode": True
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Create switch-per-node scenario (add pods workload)",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.create_routed_lport",
+                    "args": {
+                        "lport_create_args": {
+                            "batch" : 1,
+                            "port_security" : true,
+                            "ip_offset" : 2
+                        },
+                        "port_bind_args": {
+                            "internal" : true,
+                            "wait_up" : true,
+                            "wait_sync" : "ping",
+                            "batch" : false
+                        },
+                        "create_acls": true
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": {{ports_per_network}}
+                    },
+                    "sla": {
+                        "max_seconds_per_iteration": {{sla}}
+                    },
+                    "context": {
+                       "sandbox": {"tag": "ToR1"},
+                       "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                       },
+                       "ovn_nb": {},
+                       "ovn-nbctld" : {
+                            "daemon_mode": True
+                       }
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add new OVN scenario OvnNorthboundFakeMultinode which implements a test
case that brings up and configures ovn-fake-multinode nodes
(logical_switch, connect to logical_router, configure mgmt port, ping
from mgmt port to default gateway).

Also:
- Make sure all ovn-nbctl and ovs-ssh and ovs-vsctl connections are
  properly closed.
- Don't enable mcast snooping by default.
- Fix router port IP configuration and store it in the logical switch
  port info.
- Remove ovsclient.create_client logs that flood the output and bring no
  real benefit.
- Move create_routed_network implementation to ovn.py to avoid plugin
  load errors in rally.
- Enhance ovn_sandbox create_sandbox scenario to allow creating
  sandboxes based on iteration number.
- Add wait_sync=ping option for binding logical ports: will wait until
  the gateway is reachable.

Co-authored-by: Mark Michelson <mmichels@redhat.com>
Signed-off-by: Mark Michelson <mmichels@redhat.com>
Co-authored-by: Lorenzo Bianconi <lorenzo.bianconi@redhat.com>
Signed-off-by: Lorenzo Bianconi <lorenzo.bianconi@redhat.com>
Signed-off-by: Dumitru Ceara <dceara@redhat.com>