### PR TITLE
Introduce port group support to ovn-scale-test

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -241,6 +241,18 @@ class OvnNbctl(OvsClient):
                 params.append(match)
             self.run("acl-del", opts, args=params)
 
+        def port_group_add(self, port_group, port_list):
+            params = [port_group, port_list]
+            self.run("pg-add", [], params)
+
+        def port_group_set(self, port_group, port_list):
+            params = [port_group, port_list]
+            self.run("pg-set-ports", [], params)
+
+        def port_group_del(self, port_group):
+            params = [port_group]
+            self.run("pg-del", [], params)
+
         def show(self, lswitch=None):
             params = [lswitch] if lswitch else []
             stdout = StringIO()

--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -216,19 +216,22 @@ class OvnNbctl(OvsClient):
             self.run("lsp-set-options", args=params)
 
         def acl_add(self, lswitch, direction, priority, match, action,
-                    log=False):
+                    log=False, entity="switch"):
             opts = ["--log"] if log else []
+            opts.append("--type=%s" % entity)
             match = pipes.quote(match)
             params = [lswitch, direction, str(priority), match, action]
             self.run("acl-add", opts, params)
 
-        def acl_list(self, lswitch):
+        def acl_list(self, lswitch, entity="switch"):
+            opts = ["--type=" + entity]
             params = [lswitch]
-            self.run("acl-list", args=params)
+            self.run("acl-list", opts, args=params)
 
 
         def acl_del(self, lswitch, direction=None,
-                    priority=None, match=None):
+                    priority=None, match=None, entity="switch"):
+            opts = ["--type=" + entity]
             params = [lswitch]
             if direction:
                 params.append(direction)
@@ -236,7 +239,7 @@ class OvnNbctl(OvsClient):
                 params.append(priority)
             if match:
                 params.append(match)
-            self.run("acl-del", args=params)
+            self.run("acl-del", opts, args=params)
 
         def show(self, lswitch=None):
             params = [lswitch] if lswitch else []

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -186,7 +186,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
     @atomic.optional_action_timer("ovn.create_acl")
     def _create_acl(self, lswitch, lports, acl_create_args, acls_per_port):
         sw = lswitch["name"]
-        LOG.info("create %d ACLs on lswitch %s" % (acls_per_port, sw))
+        LOG.info("create %d ACLs on %s" % (acls_per_port, sw))
 
         direction = acl_create_args.get("direction", "to-lport")
         priority = acl_create_args.get("priority", 1000)
@@ -197,7 +197,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         '''
         match template: {
             "direction" : "<inport/outport>",
-            "lport" : "<switch port>",
+            "lport" : "<switch port or port-group>",
             "address_set" : "<address_set id>"
             "l4_port" : "<l4 port number>",
         }
@@ -260,6 +260,32 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         if flush:
             ovn_nbctl.flush()
 
+    @atomic.optional_action_timer("ovn.pg-add")
+    def _port_group_add(self, port_group, port_list):
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
+        ovn_nbctl.set_daemon_socket(self.context.get("daemon_socket", None))
+        LOG.info("create %s port_group [%s]" % (port_group, port_list))
+        ovn_nbctl.port_group_add(port_group, port_list)
+
+    @atomic.optional_action_timer("ovn.pg-set")
+    def _port_group_set(self, port_group, port_list):
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
+        ovn_nbctl.set_daemon_socket(self.context.get("daemon_socket", None))
+        LOG.info("Add %s to port_group %s" % (port_list, port_group))
+        ovn_nbctl.port_group_set(port_group, port_list)
+
+    @atomic.optional_action_timer("ovn.pg-del")
+    def _port_group_del(self, port_group):
+        ovn_nbctl = self.controller_client("ovn-nbctl")
+        ovn_nbctl.set_sandbox("controller-sandbox", self.install_method,
+                              self.context['controller']['host_container'])
+        ovn_nbctl.set_daemon_socket(self.context.get("daemon_socket", None))
+        LOG.info("Delete %s port_group" % port_group)
+        ovn_nbctl.port_group_del(port_group, port_list)
 
     @atomic.action_timer("ovn_network.create_routers")
     def _create_routers(self, router_create_args):

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -192,11 +192,12 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         priority = acl_create_args.get("priority", 1000)
         action = acl_create_args.get("action", "allow")
         address_set = acl_create_args.get("address_set", "")
+        acl_type = acl_create_args.get("type", "switch")
 
         '''
         match template: {
             "direction" : "<inport/outport>",
-            "lport" : "<swicth port>",
+            "lport" : "<switch port>",
             "address_set" : "<address_set id>"
             "l4_port" : "<l4 port number>",
         }
@@ -220,7 +221,8 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
                                            'lport' : lport["name"],
                                            'address_set' : address_set,
                                            'l4_port' : 100 + i }
-                ovn_nbctl.acl_add(sw, direction, priority, match, action)
+                ovn_nbctl.acl_add(sw, direction, priority, match, action,
+                                  entity = acl_type)
             ovn_nbctl.flush()
 
 


### PR DESCRIPTION
Introduce port-group support to ovn-scale-test and rely on port-groups configuring ACLs in OpenShift workload