### PR TITLE
Add the capability to attach an external command to a running test

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -458,7 +458,7 @@ class OvsSsh(OvsClient):
             self.install_method = install_method
             self.host_container = host_container
 
-        def run(self, cmd):
+        def run(self, cmd, stdout=sys.stdout):
             self.cmds = self.cmds or []
 
             if self.host_container:
@@ -469,19 +469,19 @@ class OvsSsh(OvsClient):
             if self.batch_mode:
                 return
 
-            self.flush()
+            self.flush(stdout)
 
         def run_immediate(self, cmd, stdout=sys.stdout, stderr=sys.stderr):
             self.ssh.run(cmd, stdout)
 
-        def flush(self):
+        def flush(self, stdout=sys.stdout):
             if self.cmds == None:
                 return
 
             cmds = "\n".join(self.cmds)
             self.cmds = None
 
-            self.ssh.run(cmds, stdout=sys.stdout, stderr=sys.stderr)
+            self.ssh.run(cmds, stdout=stdout, stderr=sys.stderr)
 
     def create_client(self):
         print("*********   call OvsSsh.create_client")

--- a/samples/tasks/scenarios/ovn-network/osh_workload.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload.json
@@ -1,6 +1,8 @@
 {% set farm_nodes = farm_nodes or 1 %}
 {% set networks = networks or 1 %}
 {% set ports_per_network = ports_per_network or 1 %}
+{% set cmd_start_iter = cmd_start_iter or -1 %}
+{% set cmd_stop_iter = cmd_stop_iter or -1 %}
 {
     "version": 2,
     "title": "OpenShift switch per node workload",
@@ -113,7 +115,23 @@
                         },
                         "name_space_size": 2,
                         "network_policy_size": 2,
-                        "create_acls": true
+                        "create_acls": true,
+                        "ext_cmd_args": {
+                            "start_cmd" : {
+                                "iter" : {{cmd_start_iter}},
+                                "cmd": "perf record -g -e cpu-cycles -F 99 -o ovn-perf.data",
+                                "background_opt": true,
+                                "controller_pid_name": "ovn-northd",
+                                "farm_pid_name": "ovn-controller",
+                                "pid_opt": "-p",
+                                "num_sandboxes": {{farm_nodes}}
+                            },
+                            "stop_cmd" : {
+                                "iter" : {{cmd_stop_iter}},
+                                "cmd": "killall perf",
+                                "num_sandboxes": {{farm_nodes}}
+                            }
+                        }
                     },
                     "runner": {
                         "type": "serial",

--- a/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
@@ -220,6 +220,36 @@
             ]
         },
         {
+            "title": "Run PerfTest",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.handle_cmd",
+                    "args": {
+                        "cmd_args": {
+                            "cmd": "perf record -g -e cpu-cycles -F 99 -o ovn-perf.data",
+                            "background_opt": true,
+                            "controller_pid_name": "ovn-northd",
+                            "farm_pid_name": "ovn-controller",
+                            "pid_opt": "-p",
+                            "num_sanboxes" : {{farm_nodes}}
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                       "sandbox": {"tag": "ToR1"},
+                       "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                       },
+                       "ovn_nb": {}
+                    }
+                }
+            ]
+        },
+        {
             "title": "Create switch-per-node scenario (add pods workload)",
             "run_in_parallel": true,
             "workloads": [
@@ -260,6 +290,32 @@
                             "cert": "/opt/ovn/ovn-cert.pem",
                             "cacert": "/opt/ovn/pki/switchca/cacert.pem"
                        }
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Stop PerfTest",
+            "run_in_parallel": true,
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.handle_cmd",
+                    "args": {
+                        "cmd_args": {
+                            "num_sanboxes" : {{farm_nodes}},
+                            "cmd" : "killall -w perf"
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                       "sandbox": {"tag": "ToR1"},
+                       "ovn_multihost" : {
+                            "controller": "ovn-controller-node"
+                       },
+                       "ovn_nb": {}
                     }
                 }
             ]


### PR DESCRIPTION
Introduce the capability to attach an external command (e.g perf or
strace) to a running ovn-scale-test for debugging purpose.
The external program can be attached before starting the workload
defining a given task in the json configuration file or providing
the start and stop iteration in the workload configuration