### PR TITLE
Fix ovn-sbctl calls that might hang in a clustered DB scenario.

### DIFF
--- a/rally_ovs/plugins/ovs/ovsclients_impl.py
+++ b/rally_ovs/plugins/ovs/ovsclients_impl.py
@@ -421,7 +421,7 @@ class OvnSbctl(OvsClient):
             self.run("sync", opts)
             self.batch_mode = batch_mode
 
-        def chassis_bound(self, chassis_name):
+        def chassis_bound(self, chassis_name, opts=[]):
             batch_mode = self.batch_mode
             if batch_mode:
                 self.flush()

--- a/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
@@ -92,7 +92,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
 
     def _wait_chassis(self, sbctl_conn, chassis_name, max_timeout_s):
         for i in range(0, max_timeout_s * 10):
-            if sbctl_conn.chassis_bound(chassis_name):
+            if sbctl_conn.chassis_bound(chassis_name, ["--no-leader-only"]):
                 break
             time.sleep(0.1)
 


### PR DESCRIPTION
ovn_fake_multinode scenarios check if a chassis has registered with the
SB DB by running ovn-sbctl commands on the first central instance.
However, if a leadership change happens and the first central instance
is not SB DB leader anymore, the ovn-sbctl call will hang.

To avoid such issues we add the "--no-leader-only" option to ovn-sbctl
calls in this case.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>