### PR TITLE
ovn.py: Add ovn_network.bind_port internal_vm argument.

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -539,6 +539,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
     @atomic.action_timer("ovn_network.bind_port")
     def _bind_ports(self, lports, sandboxes, port_bind_args):
         internal = port_bind_args.get("internal", False)
+        internal_vm = port_bind_args.get("internal_vm", True)
         batch = port_bind_args.get("batch", True)
         sandbox_num = len(sandboxes)
         lport_num = len(lports)
@@ -563,7 +564,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
                 j += 1
 
         self._bind_ovs_port(lport_sbs, internal)
-        if internal:
+        if internal and internal_vm:
             self._bind_ovs_internal_vm(lport_sbs)
 
     def _ping_port(self, lport, wait_timeout_s):


### PR DESCRIPTION
This controls whether the port should be simulated by a network
namespace.

Default value is "true" to maintain compatibility with older versions.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>