### PR TITLE
Move non-ovn related routines in a dedicated task

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
@@ -364,20 +364,23 @@ class OvnNorthboundFakeMultinode(OvnFakeMultinode):
         super(OvnNorthboundFakeMultinode, self).__init__(context)
 
     @scenario.configure(context={})
+    def setup_switch_per_node_init(self, fake_multinode_args = {},
+                                   lnetwork_create_args = {}):
+        self.add_chassis_nodes(fake_multinode_args)
+        if lnetwork_create_args.get('gw_router_per_network', False):
+            self.add_chassis_nodes_localnet(fake_multinode_args)
+            self.add_chassis_external_hosts(fake_multinode_args,
+                                            lnetwork_create_args)
+
+    @scenario.configure(context={})
     def setup_switch_per_node(self, fake_multinode_args = {},
                               lswitch_create_args = {},
                               lnetwork_create_args = {},
                               lport_create_args = {},
                               port_bind_args = {},
                               create_mgmt_port = True):
-        self.add_chassis_nodes(fake_multinode_args)
         self.connect_chassis_nodes(fake_multinode_args)
         self.wait_chassis_nodes(fake_multinode_args)
-
-        if lnetwork_create_args.get('gw_router_per_network', False):
-            self.add_chassis_nodes_localnet(fake_multinode_args)
-            self.add_chassis_external_hosts(fake_multinode_args,
-                                            lnetwork_create_args)
 
         lswitch_create_args['amount'] = fake_multinode_args.get('batch_size', 1)
         lswitch_create_args['batch'] = 1

--- a/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
@@ -161,6 +161,42 @@
             ]
         },
         {
+            "title": "Initialize switch_per_node scenario (setup workload)",
+            "workloads": [
+                {
+                    "name": "OvnNorthboundFakeMultinode.setup_switch_per_node_init",
+                    "args": {
+                        "fake_multinode_args": {
+                            "node_net": "192.16.0.0",
+                            "node_net_len": "16",
+                            "node_prefix": "ovn-farm-node-",
+                            "central_ip": {{ovn_central_ip}},
+                            "cluster_cmd_path": {{cluster_cmd_path}},
+                            "ovn_monitor_all": {{ovn_monitor_all}},
+                            "ovn_cluster_db": {{ovn_cluster_db}},
+                            "max_timeout_s": 10,
+                            "batch_size": {{farm_nodes}}
+                        },
+                        "lnetwork_create_args": {
+                            "start_ext_cidr": "3.0.0.0/16",
+                            "gw_router_per_network": {{gw_router}}
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "ovn_nb": {},
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {
             "title": "Create switch-per-node scenario (setup workload)",
             "workloads": [
                 {


### PR DESCRIPTION
Move the following not strictly ovn related routines in a dedicated task
in order to get more precise time estimations:
- add_chassis_nodes
- add_chassis_nodes_localnet
- add_chassis_external_hosts