### PR TITLE
ovs_client: introduce option to log commands

### DIFF
--- a/rally_ovs/plugins/ovs/context/ovn_multihost.py
+++ b/rally_ovs/plugins/ovs/context/ovn_multihost.py
@@ -59,6 +59,7 @@ class OvnMultihost(context.Context):
         "type": "object",
         "$schema": consts.JSON_SCHEMA,
         "properties": {
+            "log_cmd": {"type": "boolean"},
         },
         "additionalProperties": True
     }
@@ -88,6 +89,7 @@ class OvnMultihost(context.Context):
 
 
         self.context["controller"] = res["info"]
+        self.context["log_cmd"] = self.config.get("log_cmd", False)
 
 
 

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -30,6 +30,7 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         ovn_nbctl.set_sandbox("controller-sandbox", install_method,
                               self.context['controller']['host_container'])
         ovn_nbctl.set_daemon_socket(self.context.get("daemon_socket", None))
+        ovn_nbctl.set_log_cmd(self.context.get("log_cmd", False))
         return ovn_nbctl
 
     def _start_daemon(self, nbctld_config):

--- a/rally_ovs/plugins/ovs/ovsclients.py
+++ b/rally_ovs/plugins/ovs/ovsclients.py
@@ -17,6 +17,7 @@ import collections
 import six
 import re
 import netaddr
+import logging
 
 from rally.common.plugin import plugin
 from rally.task import scenario
@@ -25,11 +26,18 @@ from io import StringIO
 
 _NAMESPACE = "ovs"
 
+LOG = logging.getLogger(__name__)
 
 def configure(name):
     return plugin.configure(name, namespace=_NAMESPACE)
 
+class OvsClientLogger(object):
+    def set_log_cmd(self, log_cmd=False):
+        self.log_cmd = log_cmd
 
+    def log_cmds(self, cmds):
+        if self.log_cmd:
+            LOG.info(cmds)
 
 class OvsClient(plugin.Plugin):
     def __init__(self, credential, cache_obj):

--- a/rally_ovs/plugins/ovs/scenarios/ovn.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn.py
@@ -53,6 +53,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             ovs_ssh = self.farm_clients(farm, "ovs-ssh")
             ovs_ssh.set_sandbox(sb_name, self.install_method,
                                 sandbox["host_container"])
+            ovs_ssh.set_log_cmd(self.context.get("log_cmd", False))
             ovs_ssh.enable_batch_mode()
             self._ssh_conns[sb_name] = ovs_ssh
 
@@ -437,6 +438,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             ovs_vsctl = self.farm_clients(farm, "ovs-vsctl")
             ovs_vsctl.set_sandbox(sb_name, self.install_method,
                                   sandbox['host_container'])
+            ovs_vsctl.set_log_cmd(self.context.get("log_cmd", False))
             ovs_vsctl.enable_batch_mode()
             for lport in lports:
                 port_name = lport["name"]
@@ -457,6 +459,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             ovs_ssh = self.farm_clients(farm, "ovs-ssh")
             ovs_ssh.set_sandbox(sb_name, self.install_method,
                                 sandbox['host_container'])
+            ovs_ssh.set_log_cmd(self.context.get("log_cmd", False))
             for lport in lports:
                 port_name = lport["name"]
                 port_mac = lport["mac"]
@@ -500,11 +503,13 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
 
         ovs_vsctl = self.farm_clients(farm, "ovs-vsctl")
         ovs_vsctl.set_sandbox(sandbox, self.install_method, host_container)
+        ovs_vsctl.set_log_cmd(self.context.get("log_cmd", False))
         ovs_vsctl.run("find interface type=internal", ["--bare", "--columns", "name"], stdout=stdout)
         output = stdout.getvalue()
 
         ovs_ssh = self.farm_clients(farm, "ovs-ssh")
         ovs_ssh.set_sandbox(sb_name, self.install_method, host_container)
+        ovs_ssh.set_log_cmd(self.context.get("log_cmd", False))
 
         for name in list(filter(None, output.splitlines())):
             if "lp" not in name:
@@ -520,10 +525,12 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             ovs_ssh = self.farm_clients(farm, "ovs-ssh")
             ovs_ssh.set_sandbox(sb_name, self.install_method,
                                 host_container)
+            ovs_ssh.set_log_cmd(self.context.get("log_cmd", False))
             ovs_ssh.enable_batch_mode()
             ovs_vsctl = self.farm_clients(farm, "ovs-vsctl")
             ovs_vsctl.set_sandbox(sandbox, self.install_method,
                                   host_container)
+            ovs_vsctl.set_log_cmd(self.context.get("log_cmd", False))
             ovs_vsctl.enable_batch_mode()
             conns[sb_name] = (ovs_ssh, ovs_vsctl)
 
@@ -572,6 +579,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         ovs_ssh = self.farm_clients(sandbox["farm"], "ovs-ssh")
         ovs_ssh.set_sandbox(sandbox, self.install_method,
                             sandbox['host_container'])
+        ovs_ssh.set_log_cmd(self.context.get("log_cmd", False))
         ovs_ssh.enable_batch_mode(False)
 
         if lport.get("ext-gw"):
@@ -636,6 +644,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
             ovs_ofctl = self.farm_clients(farm, "ovs-ofctl")
             ovs_ofctl.set_sandbox(sandbox_name, self.install_method,
                                   host_container)
+            ovs_ofctl.set_log_cmd(self.context.get("log_cmd", False))
             bridge = sandbox_args.get('bridge', 'br-int')
             lflow_count = ovs_ofctl.dump_flows(bridge)
 
@@ -716,6 +725,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         ssh = self.farm_clients(sandbox["farm"], "ovs-ssh")
         ssh.set_sandbox(sandbox["name"], self.install_method,
                         sandbox["host_container"])
+        ssh.set_log_cmd(self.context.get("log_cmd", False))
 
         if pid_proc_name:
             pid = self.runCmd(ssh, "pidof -s " + pid_proc_name)
@@ -731,6 +741,7 @@ class OvnScenario(ovnclients.OvnClientMixin, scenario.OvsScenario):
         ssh = self.controller_client("ovs-ssh")
         ssh.set_sandbox("controller-sandbox", self.install_method,
                         self.context["controller"]["host_container"])
+        ssh.set_log_cmd(self.context.get("log_cmd", False))
 
         if pid_proc_name:
             pid = self.runCmd(ssh, "pidof -s " + pid_proc_name)

--- a/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_fake_multinode.py
@@ -39,6 +39,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
         farm = sb["farm"]
         ssh = self.farm_clients(farm, "ovs-ssh")
         ssh.set_sandbox(sb_name, self.install_method, host_container)
+        ssh.set_log_cmd(self.context.get("log_cmd", False))
         ssh.enable_batch_mode(False)
         return ssh
 
@@ -142,6 +143,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
     def add_central_node(self, fake_multinode_args = {}):
         ssh = self.controller_client("ovs-ssh")
         ssh.set_sandbox("controller-sandbox", self.install_method)
+        ssh.set_log_cmd(self.context.get("log_cmd", False))
         ssh.enable_batch_mode(False)
 
         node_net = fake_multinode_args.get("node_net")
@@ -198,6 +200,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
         ovn_sbctl.set_sandbox("controller-sandbox", self.install_method,
                               self.context['controller']['host_container'])
         ovn_sbctl.enable_batch_mode(False)
+        ovn_sbctl.set_log_cmd(self.context.get("log_cmd", False))
         self._wait_chassis(ovn_sbctl, node_name, max_timeout_s)
 
     @scenario.configure(context={})
@@ -216,6 +219,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
     def del_central_node(self, fake_multinode_args = {}):
         ssh = self.controller_client("ovs-ssh")
         ssh.set_sandbox("controller-sandbox", self.install_method)
+        ssh.set_log_cmd(self.context.get("log_cmd", False))
         ssh.enable_batch_mode(False)
 
         ovn_fake_path = fake_multinode_args.get("cluster_cmd_path")
@@ -293,6 +297,7 @@ class OvnFakeMultinode(ovn.OvnScenario):
         ovn_sbctl.set_sandbox("controller-sandbox", self.install_method,
                               self.context['controller']['host_container'])
         ovn_sbctl.enable_batch_mode(False)
+        ovn_sbctl.set_log_cmd(self.context.get("log_cmd", False))
         for i in range(batch_size):
             index = iteration * batch_size + i
 

--- a/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_igmp.py
@@ -40,6 +40,7 @@ class OvnIGMP(ovn_network.OvnNetwork):
         for iteration in range(0, 60):
             LOG.info('Iteration {}'.format(iteration))
             ovn_sbctl = self.controller_client("ovn-sbctl")
+            ovn_sbctl.set_log_cmd(self.context.get("log_cmd", False))
             igmp_flow_count = 0
             for lswitch in lswitches:
                 igmp_flow_count += ovn_sbctl.count_igmp_flows(lswitch['name'])
@@ -147,6 +148,7 @@ class OvnIGMP(ovn_network.OvnNetwork):
 
         # Avoid lazy connection creation:
         ovn_sbctl = self.controller_client("ovn-sbctl")
+        ovn_sbctl.set_log_cmd(self.context.get("log_cmd", False))
 
         # Build configuration for each port for each iteration
         iterations = self._build_config_testers(lswitches, all_lports,

--- a/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
@@ -324,6 +324,7 @@
                     "context": {
                        "sandbox": {"tag": "ToR1"},
                        "ovn_multihost" : {
+                            "log_cmd": True,
                             "controller": "ovn-controller-node"
                        },
                        "ovn_nb": {},


### PR DESCRIPTION
Introduce log_cmd option to log ovn-nbctl, ovn-sbctl, ovs-ssh, ovs-vsctl
and ovs-ofctl commands