### PR TITLE
Add new scenario ovn_run_command().

### DIFF
--- a/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
+++ b/rally_ovs/plugins/ovs/scenarios/ovn_nb.py
@@ -235,17 +235,21 @@ class OvnNorthbound(ovn.OvnScenario):
         lswitch = lswitches[iteration % len(lswitches)]
         ip_start_index = iteration / len(lswitches) + ip_offset
 
+        self.ovn_run_command(ext_cmd_args)
+        self.configure_routed_lport(lswitch, lport_create_args,
+                                    port_bind_args, ip_start_index,
+                                    name_space_size, network_policy_size,
+                                    create_acls)
+
+    @scenario.configure()
+    def ovn_run_command(self, ext_cmd_args = {}):
+        iteration = self.context["iteration"]
         start_cmd = ext_cmd_args.get("start_cmd", None)
         if start_cmd and iteration == start_cmd.get("iter", -1):
                self.handle_cmd(start_cmd)
         stop_cmd = ext_cmd_args.get("stop_cmd", None)
         if stop_cmd and iteration == stop_cmd.get("iter", -1):
                self.handle_cmd(stop_cmd)
-
-        self.configure_routed_lport(lswitch, lport_create_args,
-                                    port_bind_args, ip_start_index,
-                                    name_space_size, network_policy_size,
-                                    create_acls)
 
     @scenario.configure()
     def handle_cmd(self, cmd_args = {}):

--- a/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
@@ -9,6 +9,8 @@
 {% set cluster_cmd_path = cluster_cmd_path or "/root/ovn-fake-testing/ovn-fake-multinode" %}
 {% set node_batch_size = node_batch_size or 1 %}
 {% set sla = sla or 30 %}
+{% set use_dp_groups = use_dp_groups or True %}
+{% set sb_raft_election_to = sb_raft_election_to or 1 %}
 {
     "version": 2,
     "title": "Switch per node workload",
@@ -160,6 +162,62 @@
                 }
             ]
         },
+        {
+            "title": "Configure dp_groups",
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.ovn_run_command",
+                    "args": {
+                        "ext_cmd_args": {
+                            "start_cmd" : {
+                                "iter" : 0,
+                                "cmd": "ovn-nbctl --no-leader-only set NB_Global . options:use_logical_dp_groups={{use_dp_groups}}",
+                                "controller_pid_name": "ovn-northd",
+                            }
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% for timeout in range(1000, (sb_raft_election_to + 1) * 1000, 1000) %}
+        {
+            "title": "Configure RAFT election timeout",
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.ovn_run_command",
+                    "args": {
+                        "ext_cmd_args": {
+                            "start_cmd" : {
+                                "iter" : 0,
+                                "cmd": "ovs-appctl -t /run/ovn/ovnsb_db.ctl cluster/change-election-timer OVN_Southbound {{timeout}}",
+                                "controller_pid_name": "ovn-northd",
+                            }
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% endfor %}
         {
             "title": "Initialize switch_per_node scenario (setup workload)",
             "workloads": [


### PR DESCRIPTION
This allows running custom commands on the test cluster, e.g., enable DP
groups or configure RAFT election timeouts.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>